### PR TITLE
Add windows exe and vim backups to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ bootstrap/cmd/pegscan/pegscan
 bootstrap/cmd/pegparse/pegparse
 bin/
 pigeon
+*.exe
+*~


### PR DESCRIPTION
Better gitignore, if working with Windows.
Exclude vim backup files.