### PR TITLE
Integrate goimports functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: go
 
+install: go get golang.org/x/tools/imports/...
+
 script: go test -v ./...
 
 go:
-    - 1.1.x
     - 1.2.x
     - 1.3.x
     - 1.4.x

--- a/Makefile
+++ b/Makefile
@@ -38,14 +38,14 @@ $(BINDIR)/bootstrap-build: $(BOOTSTRAPBUILD_SRC) $(BOOTSTRAP_SRC) $(BUILDER_SRC)
 
 $(BOOTSTRAPPIGEON_DIR)/bootstrap_pigeon.go: $(BINDIR)/bootstrap-build \
 	$(BOOTSTRAP_GRAMMAR)
-	$(BINDIR)/bootstrap-build $(BOOTSTRAP_GRAMMAR) | goimports > $@
+	$(BINDIR)/bootstrap-build $(BOOTSTRAP_GRAMMAR) > $@
 
 $(BINDIR)/bootstrap-pigeon: $(BOOTSTRAPPIGEON_SRC) \
 	$(BOOTSTRAPPIGEON_DIR)/bootstrap_pigeon.go
 	go build -o $@ $(BOOTSTRAPPIGEON_DIR)
 
 $(ROOT)/pigeon.go: $(BINDIR)/bootstrap-pigeon $(PIGEON_GRAMMAR)
-	$(BINDIR)/bootstrap-pigeon $(PIGEON_GRAMMAR) | goimports > $@
+	$(BINDIR)/bootstrap-pigeon $(PIGEON_GRAMMAR) > $@
 
 $(BINDIR)/pigeon: $(ROOT_SRC) $(ROOT)/pigeon.go
 	go build -o $@ $(ROOT)
@@ -56,33 +56,33 @@ $(PIGEON_GRAMMAR):
 # surely there's a better way to define the examples and test targets
 
 $(EXAMPLES_DIR)/json/json.go: $(EXAMPLES_DIR)/json/json.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< | goimports > $@
+	$(BINDIR)/pigeon $< > $@
 
 $(EXAMPLES_DIR)/calculator/calculator.go: $(EXAMPLES_DIR)/calculator/calculator.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< | goimports > $@
+	$(BINDIR)/pigeon $< > $@
 
 $(TEST_DIR)/andnot/andnot.go: $(TEST_DIR)/andnot/andnot.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< | goimports > $@
+	$(BINDIR)/pigeon $< > $@
 
 $(TEST_DIR)/predicates/predicates.go: $(TEST_DIR)/predicates/predicates.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< | goimports > $@
+	$(BINDIR)/pigeon $< > $@
 
 $(TEST_DIR)/issue_1/issue_1.go: $(TEST_DIR)/issue_1/issue_1.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< | goimports > $@
+	$(BINDIR)/pigeon $< > $@
 
 $(TEST_DIR)/linear/linear.go: $(TEST_DIR)/linear/linear.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< | goimports > $@
+	$(BINDIR)/pigeon $< > $@
 
 $(TEST_DIR)/issue_12/issue_12.go: $(TEST_DIR)/issue_12/issue_12.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< | goimports > $@
+	$(BINDIR)/pigeon $< > $@
 
 lint:
 	golint ./...
 	go vet ./...
 
 cmp:
-	@boot=$$(mktemp) && $(BINDIR)/bootstrap-pigeon $(PIGEON_GRAMMAR) | goimports > $$boot && \
-	official=$$(mktemp) && $(BINDIR)/pigeon $(PIGEON_GRAMMAR) | goimports > $$official && \
+	@boot=$$(mktemp) && $(BINDIR)/bootstrap-pigeon $(PIGEON_GRAMMAR) > $$boot && \
+	official=$$(mktemp) && $(BINDIR)/pigeon $(PIGEON_GRAMMAR) > $$official && \
 	cmp $$boot $$official && \
 	unlink $$boot && \
 	unlink $$official

--- a/README.md
+++ b/README.md
@@ -24,19 +24,7 @@ This will install or update the package, and the `pigeon` command will be instal
 $ pigeon [options] [PEG_GRAMMAR_FILE]
 ```
 
-By default, the input grammar is read from `stdin` and the generated code is printed to `stdout`. You may save it in a file using the `-o` flag, but pigeon makes no attempt to format the generated code, nor does it try to generate the required imports, because such a tool already exists. The recommended way to generate a properly formatted and working parser is to pipe the output of pigeon through the `goimports` tool:
-
-```
-$ pigeon my_revolutionary_programming_language.peg | goimports > main.go
-```
-
-This way, the generated code has all the necessary imports and is properly formatted. You can install `goimports` using:
-
-```
-$ go get golang.org/x/tools/cmd/goimports
-```
-
-See the [godoc page][3] for detailed usage.
+By default, the input grammar is read from `stdin` and the generated code is printed to `stdout`. You may save it in a file using the `-o` flag.
 
 ## Example
 

--- a/bootstrap/cmd/bootstrap-build/main.go
+++ b/bootstrap/cmd/bootstrap-build/main.go
@@ -4,10 +4,13 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+
+	"golang.org/x/tools/imports"
 
 	"github.com/mna/pigeon/bootstrap"
 	"github.com/mna/pigeon/builder"
@@ -46,7 +49,26 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err := builder.BuildParser(outw, g); err != nil {
+	outBuf := bytes.NewBuffer([]byte{})
+
+	if err := builder.BuildParser(outBuf, g); err != nil {
+		log.Fatal(err)
+	}
+
+	// Defaults from golang.org/x/tools/cmd/goimports
+	options := &imports.Options{
+		TabWidth:  8,
+		TabIndent: true,
+		Comments:  true,
+		Fragment:  true,
+	}
+
+	formattedBuf, err := imports.Process("filename", outBuf.Bytes(), options)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if _, err := outw.Write(formattedBuf); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/bootstrap/cmd/bootstrap-pigeon/main.go
+++ b/bootstrap/cmd/bootstrap-pigeon/main.go
@@ -6,9 +6,12 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"flag"
 	"fmt"
 	"os"
+
+	"golang.org/x/tools/imports"
 
 	"github.com/mna/pigeon/ast"
 	"github.com/mna/pigeon/builder"
@@ -57,9 +60,30 @@ func main() {
 			outw = f
 		}
 
-		if err := builder.BuildParser(outw, g.(*ast.Grammar)); err != nil {
+		outBuf := bytes.NewBuffer([]byte{})
+
+		if err := builder.BuildParser(outBuf, g.(*ast.Grammar)); err != nil {
 			fmt.Fprintln(os.Stderr, "build error: ", err)
 			os.Exit(5)
+		}
+
+		// Defaults from golang.org/x/tools/cmd/goimports
+		options := &imports.Options{
+			TabWidth:  8,
+			TabIndent: true,
+			Comments:  true,
+			Fragment:  true,
+		}
+
+		formattedBuf, err := imports.Process("filename", outBuf.Bytes(), options)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "format error: ", err)
+			os.Exit(6)
+		}
+
+		if _, err := outw.Write(formattedBuf); err != nil {
+			fmt.Fprintln(os.Stderr, "write error: ", err)
+			os.Exit(7)
 		}
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -49,14 +49,6 @@ The following options can be specified:
 	code blocks. Non-initializer code blocks in the grammar end up as methods on the
 	*current type, and this option sets the name of the receiver (default: c).
 
-The tool makes no attempt to format the code, nor to detect the
-required imports. It is recommended to use goimports to properly generate
-the output code:
-	pigeon GRAMMAR_FILE | goimports > output_file.go
-
-The goimports tool can be installed with:
-	go get golang.org/x/tools/cmd/goimports
-
 If the code blocks in the grammar (see below, section "Code block") are golint-
 and go vet-compliant, then the resulting generated code will also be golint-
 and go vet-compliant.


### PR DESCRIPTION
pigeon already heavily depends on goimports (e.g. in the Makefile) and also suggests the user to use it to cleanup the generated code. The integration of the functionality of goimports is very easy (actually only creating a buffer and execute one call to `imports.Process` so I feel it is worth it to integrate this functionality directly into pigeon.
It is my opinion, pigeon should generate valid code directly.