### PR TITLE
Reorganize .gitignore, added *.out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,22 @@
-.*.swp
-.*.swo
-.swp
-*.test
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+pigeon
+bin/
 bootstrap/cmd/bootstrap-pigeon/bootstrap-pigeon
 bootstrap/cmd/bootstrap-build/bootstrap-build
 bootstrap/cmd/pegscan/pegscan
 bootstrap/cmd/pegparse/pegparse
-bin/
-pigeon
-*.exe
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Temporary and swap files
+*.swp
+*.swo
 *~


### PR DESCRIPTION
Reorganized .gitignore based on template from https://www.gitignore.io/api/go
Added *.out for coverage output