### PR TITLE
Better error reporting based on farthest parse pos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ $(TEST_DIR)/linear/linear.go: $(TEST_DIR)/linear/linear.peg $(BINDIR)/pigeon
 $(TEST_DIR)/issue_12/issue_12.go: $(TEST_DIR)/issue_12/issue_12.peg $(BINDIR)/pigeon
 	$(BINDIR)/pigeon $< > $@
 
+$(TEST_DIR)/errorpos/errorpos.go: $(TEST_DIR)/errorpos/errorpos.peg $(BINDIR)/pigeon
+	$(BINDIR)/pigeon $< > $@
+
 lint:
 	golint ./...
 	go vet ./...

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -2222,6 +2223,19 @@ func Recover(b bool) Option {
 	}
 }
 
+// FailureTracking creates an Option to set failureTracking flag to b.
+// When set to true, this causes the parser to track the farthest failures
+// and report them, if the parsing of the input fails.
+//
+// The default is false.
+func FailureTracking(b bool) Option {
+	return func(p *parser) Option {
+		old := p.failureTracking
+		p.failureTracking = b
+		return Recover(old)
+	}
+}
+
 // ParseFile parses the file identified by filename.
 func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 	f, err := os.Open(filename)
@@ -2415,11 +2429,13 @@ func (p *parserError) Error() string {
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
 	p := &parser{
-		filename: filename,
-		errs:     new(errList),
-		data:     b,
-		pt:       savepoint{position: position{line: 1}},
-		recover:  true,
+		filename:        filename,
+		errs:            new(errList),
+		data:            b,
+		pt:              savepoint{position: position{line: 1}},
+		recover:         true,
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make(map[string]struct{}),
 	}
 	p.setOptions(opts)
 	return p
@@ -2464,6 +2480,12 @@ type parser struct {
 
 	// stats
 	exprCnt int
+
+	// parse fail
+	failureTracking       bool
+	maxFailPos            position
+	maxFailExpected       map[string]struct{}
+	maxFailInvertExpected bool
 }
 
 // push a variable set on the vstack.
@@ -2646,8 +2668,28 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			// make sure this doesn't go out silently
-			p.addErr(errNoMatch)
+			if p.failureTracking {
+				// If parsing fails, but no errors have been recorded, the expected values
+				// for the farthest parser position are returned as error.
+				var expected []string
+				eof := ""
+				if _, ok := p.maxFailExpected["!."]; ok {
+					delete(p.maxFailExpected, "!.")
+					if len(p.maxFailExpected) > 0 {
+						eof = " or EOF"
+					} else {
+						eof = "EOF"
+					}
+				}
+				for k := range p.maxFailExpected {
+					expected = append(expected, k)
+				}
+				sort.Strings(expected)
+				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
+			} else {
+				// make sure this doesn't go out silently
+				p.addErr(errNoMatch)
+			}
 		}
 		return nil, p.errs.err()
 	}
@@ -2793,8 +2835,10 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	if p.pt.rn != utf8.RuneError {
 		start := p.pt
 		p.read()
+		p.failAt(true, start.position, ".")
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, p.pt.position, ".")
 	return nil, false
 }
 
@@ -2804,11 +2848,12 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	}
 
 	cur := p.pt.rn
+	start := p.pt
 	// can't match EOF
 	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
-	start := p.pt
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}
@@ -2817,9 +2862,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, rn := range chr.chars {
 		if rn == cur {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -2828,9 +2875,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for i := 0; i < len(chr.ranges); i += 2 {
 		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -2839,17 +2888,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, cl := range chr.classes {
 		if unicode.Is(cl, cur) {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
 
 	if chr.inverted {
 		p.read()
+		p.failAt(true, start.position, chr.val)
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, start.position, chr.val)
 	return nil, false
 }
 
@@ -2889,6 +2942,11 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -2896,12 +2954,33 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
+			p.failAt(false, start.position, val)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
+	p.failAt(true, start.position, val)
 	return p.sliceFrom(start), true
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if p.failureTracking && fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = make(map[string]struct{})
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected[want] = struct{}{}
+	}
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
@@ -2923,7 +3002,9 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 
 	pt := p.pt
 	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
 	p.restore(pt)
 	return nil, !ok

--- a/doc.go
+++ b/doc.go
@@ -295,6 +295,7 @@ as a package with public functions to parse input text. The exported API is:
 	- Debug(bool) Option
 	- Memoize(bool) Option
 	- Recover(bool) Option
+	- FailureTracking(bool) Option
 
 See the godoc page of the generated parser for the test/predicates grammar
 for an example documentation page of the exported API:
@@ -375,6 +376,10 @@ In order to do this, the grammar can look something like this:
 
 This is just one example, but it illustrates the idea that error reporting
 needs to be thought out when designing the grammar.
+
+By providing the FailureTracking(true) Option, the parser will keep track of the
+failed matches and provide the farthest failed parsing position as the error,
+which in most cases provides a reasonable error message.
 
 API stability
 

--- a/pigeon.go
+++ b/pigeon.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -2889,6 +2890,19 @@ func Recover(b bool) Option {
 	}
 }
 
+// FailureTracking creates an Option to set failureTracking flag to b.
+// When set to true, this causes the parser to track the farthest failures
+// and report them, if the parsing of the input fails.
+//
+// The default is false.
+func FailureTracking(b bool) Option {
+	return func(p *parser) Option {
+		old := p.failureTracking
+		p.failureTracking = b
+		return Recover(old)
+	}
+}
+
 // ParseFile parses the file identified by filename.
 func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 	f, err := os.Open(filename)
@@ -3082,11 +3096,13 @@ func (p *parserError) Error() string {
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
 	p := &parser{
-		filename: filename,
-		errs:     new(errList),
-		data:     b,
-		pt:       savepoint{position: position{line: 1}},
-		recover:  true,
+		filename:        filename,
+		errs:            new(errList),
+		data:            b,
+		pt:              savepoint{position: position{line: 1}},
+		recover:         true,
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make(map[string]struct{}),
 	}
 	p.setOptions(opts)
 	return p
@@ -3131,6 +3147,12 @@ type parser struct {
 
 	// stats
 	exprCnt int
+
+	// parse fail
+	failureTracking       bool
+	maxFailPos            position
+	maxFailExpected       map[string]struct{}
+	maxFailInvertExpected bool
 }
 
 // push a variable set on the vstack.
@@ -3313,8 +3335,28 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			// make sure this doesn't go out silently
-			p.addErr(errNoMatch)
+			if p.failureTracking {
+				// If parsing fails, but no errors have been recorded, the expected values
+				// for the farthest parser position are returned as error.
+				var expected []string
+				eof := ""
+				if _, ok := p.maxFailExpected["!."]; ok {
+					delete(p.maxFailExpected, "!.")
+					if len(p.maxFailExpected) > 0 {
+						eof = " or EOF"
+					} else {
+						eof = "EOF"
+					}
+				}
+				for k := range p.maxFailExpected {
+					expected = append(expected, k)
+				}
+				sort.Strings(expected)
+				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
+			} else {
+				// make sure this doesn't go out silently
+				p.addErr(errNoMatch)
+			}
 		}
 		return nil, p.errs.err()
 	}
@@ -3460,8 +3502,10 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	if p.pt.rn != utf8.RuneError {
 		start := p.pt
 		p.read()
+		p.failAt(true, start.position, ".")
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, p.pt.position, ".")
 	return nil, false
 }
 
@@ -3471,11 +3515,12 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	}
 
 	cur := p.pt.rn
+	start := p.pt
 	// can't match EOF
 	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
-	start := p.pt
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}
@@ -3484,9 +3529,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, rn := range chr.chars {
 		if rn == cur {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -3495,9 +3542,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for i := 0; i < len(chr.ranges); i += 2 {
 		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -3506,17 +3555,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, cl := range chr.classes {
 		if unicode.Is(cl, cur) {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
 
 	if chr.inverted {
 		p.read()
+		p.failAt(true, start.position, chr.val)
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, start.position, chr.val)
 	return nil, false
 }
 
@@ -3556,6 +3609,11 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -3563,12 +3621,33 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
+			p.failAt(false, start.position, val)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
+	p.failAt(true, start.position, val)
 	return p.sliceFrom(start), true
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if p.failureTracking && fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = make(map[string]struct{})
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected[want] = struct{}{}
+	}
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
@@ -3590,7 +3669,9 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 
 	pt := p.pt
 	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
 	p.restore(pt)
 	return nil, !ok

--- a/test/errorpos/errorpos.peg
+++ b/test/errorpos/errorpos.peg
@@ -1,0 +1,25 @@
+{
+package errorpos
+}
+
+Input ← _ (case01 / case02 / case03 / case04 / case05 / case06 / case07 / case08 / case09 / case10 / case11) EOF
+
+case01 ← "case01" _ ((increment / decrement / zero) _ )+
+case02 ← "case02" __ [^abc]+
+case03 ← "case03" __ "x"? [0-9]
+case04 ← "case04" __ [\x30-\x39] [^\x30-\x39] [\pN] [^\pN]
+case05 ← "case05" __ !"not" "yes"
+case06 ← "case06" __ ![0-9] "x"
+case07 ← "case07" __ !("abc"i / [a-c]i / [\pL]) [0-9]
+case08 ← "case08" __ &"a"i .
+case09 ← "case09" __ &[0-9] .
+case10 ← "case10" __ &("0" / [012] / [3-9] / [\pN]) .
+case11 ← "case11" __ !(!("a")) "a"
+
+increment ← "inc"
+decrement ← "dec"
+zero ← "zero"
+oneOrMore ← "oneOrMore"
+_ ← [ \t\n\r]*
+__ ← [ ]
+EOF ← !.

--- a/test/errorpos/errorpos_test.go
+++ b/test/errorpos/errorpos_test.go
@@ -1,0 +1,55 @@
+package errorpos
+
+import "testing"
+
+// ABs must end in Bs, CDs must end in Ds
+var cases = map[string]string{
+	"case01 zero":           ``,
+	" case01 inc dec zero ": ``,
+	"":                `1:1 (0): no match found, expected: "case01", "case02", "case03", "case04", "case05", "case06", "case07", "case08", "case09", "case10", "case11", [ \t\n\r]`,
+	"kase01":          `1:1 (0): no match found, expected: "case01", "case02", "case03", "case04", "case05", "case06", "case07", "case08", "case09", "case10", "case11", [ \t\n\r]`,
+	"case01 zero ink": `1:13 (12): no match found, expected: "dec", "inc", "zero", [ \t\n\r] or EOF`,
+	"case02 xyz":      ``,
+	"case02 ":         `1:8 (7): no match found, expected: [^abc]`,
+	"case02xyz":       `1:7 (6): no match found, expected: [ ]`,
+	"case02 abc":      `1:8 (7): no match found, expected: [^abc]`,
+	"case02 xya":      `1:10 (9): no match found, expected: [^abc] or EOF`,
+	"case03 0":        ``,
+	"case03 x0":       ``,
+	"case03 y":        `1:8 (7): no match found, expected: "x", [0-9]`,
+	"case03 xy":       `1:9 (8): no match found, expected: [0-9]`,
+	"case03 10":       `1:9 (8): no match found, expected: EOF`,
+	"case04 0x0x":     ``,
+	"case04 x":        `1:8 (7): no match found, expected: [\x30-\x39]`,
+	"case04 00":       `1:9 (8): no match found, expected: [^\x30-\x39]`,
+	"case04 0xx":      `1:10 (9): no match found, expected: [\pN]`,
+	"case04 0x00":     `1:11 (10): no match found, expected: [^\pN]`,
+	"case05 yes":      ``,
+	"case05 not":      `1:8 (7): no match found, expected: !"not"`,
+	"case06 x":        ``,
+	"case06 0":        `1:8 (7): no match found, expected: ![0-9]`,
+	"case07 0":        ``,
+	"case07 a":        `1:8 (7): no match found, expected: ![a-c]i`,
+	"case08 a":        ``,
+	"case08 b":        `1:8 (7): no match found, expected: "a"i`,
+	"case09 0":        ``,
+	"case09 a":        `1:8 (7): no match found, expected: [0-9]`,
+	"case10 9":        ``,
+	"case10 x":        `1:8 (7): no match found, expected: "0", [012], [3-9], [\pN]`,
+	"case11 a":        ``,
+	"case11 b":        `1:8 (7): no match found, expected: "a"`,
+}
+
+func TestAndNot(t *testing.T) {
+	for tc, exp := range cases {
+		_, err := Parse("", []byte(tc), FailureTracking(true))
+		var got string
+		if err != nil {
+			got = err.Error()
+		}
+		if got != exp {
+			_, _ = Parse("", []byte(tc), FailureTracking(true), Debug(true))
+			t.Errorf("%q: want %v, got %v", tc, exp, got)
+		}
+	}
+}


### PR DESCRIPTION
The parser stores the farthest position together with the expected
values, just before the backtracking starts. If the parsing fails,
this position together with the expected values are returned
as the error instead of the generic "1:1 (0): no match found".

Fixes #18