### PR TITLE
Add FailureTracking as flag to pigeon and to existing tests and examples.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ $(TEST_DIR)/linear/linear.go: $(TEST_DIR)/linear/linear.peg $(BINDIR)/pigeon
 $(TEST_DIR)/issue_12/issue_12.go: $(TEST_DIR)/issue_12/issue_12.peg $(BINDIR)/pigeon
 	$(BINDIR)/pigeon $< > $@
 
+$(TEST_DIR)/errorpos/errorpos.go: $(TEST_DIR)/errorpos/errorpos.peg $(BINDIR)/pigeon
+	$(BINDIR)/pigeon $< > $@
+
 lint:
 	golint ./...
 	go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ $(TEST_DIR)/linear/linear.go: $(TEST_DIR)/linear/linear.peg $(BINDIR)/pigeon
 $(TEST_DIR)/issue_12/issue_12.go: $(TEST_DIR)/issue_12/issue_12.peg $(BINDIR)/pigeon
 	$(BINDIR)/pigeon $< > $@
 
+$(TEST_DIR)/issue_18/issue_18.go: $(TEST_DIR)/issue_18/issue_18.peg $(BINDIR)/pigeon
+	$(BINDIR)/pigeon $< > $@
+
 $(TEST_DIR)/errorpos/errorpos.go: $(TEST_DIR)/errorpos/errorpos.peg $(BINDIR)/pigeon
 	$(BINDIR)/pigeon $< > $@
 

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2232,7 +2232,7 @@ func FailureTracking(b bool) Option {
 	return func(p *parser) Option {
 		old := p.failureTracking
 		p.failureTracking = b
-		return Recover(old)
+		return FailureTracking(old)
 	}
 }
 

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -2222,6 +2223,19 @@ func Recover(b bool) Option {
 	}
 }
 
+// FailureTracking creates an Option to set failureTracking flag to b.
+// When set to true, this causes the parser to track the farthest failures
+// and report them, if the parsing of the input fails.
+//
+// The default is false.
+func FailureTracking(b bool) Option {
+	return func(p *parser) Option {
+		old := p.failureTracking
+		p.failureTracking = b
+		return Recover(old)
+	}
+}
+
 // ParseFile parses the file identified by filename.
 func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 	f, err := os.Open(filename)
@@ -2415,11 +2429,13 @@ func (p *parserError) Error() string {
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
 	p := &parser{
-		filename: filename,
-		errs:     new(errList),
-		data:     b,
-		pt:       savepoint{position: position{line: 1}},
-		recover:  true,
+		filename:        filename,
+		errs:            new(errList),
+		data:            b,
+		pt:              savepoint{position: position{line: 1}},
+		recover:         true,
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make(map[string]struct{}),
 	}
 	p.setOptions(opts)
 	return p
@@ -2464,6 +2480,12 @@ type parser struct {
 
 	// stats
 	exprCnt int
+
+	// parse fail
+	failureTracking       bool
+	maxFailPos            position
+	maxFailExpected       map[string]struct{}
+	maxFailInvertExpected bool
 }
 
 // push a variable set on the vstack.
@@ -2646,8 +2668,28 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			// make sure this doesn't go out silently
-			p.addErr(errNoMatch)
+			if p.failureTracking {
+				// If parsing fails, but no errors have been recorded, the expected values
+				// for the farthest parser position are returned as error.
+				var expected []string
+				eof := ""
+				if _, ok := p.maxFailExpected["!."]; ok {
+					delete(p.maxFailExpected, "!.")
+					if len(p.maxFailExpected) > 0 {
+						eof = " or EOF"
+					} else {
+						eof = "EOF"
+					}
+				}
+				for k := range p.maxFailExpected {
+					expected = append(expected, k)
+				}
+				sort.Strings(expected)
+				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
+			} else {
+				// make sure this doesn't go out silently
+				p.addErr(errNoMatch)
+			}
 		}
 		return nil, p.errs.err()
 	}
@@ -2793,8 +2835,10 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	if p.pt.rn != utf8.RuneError {
 		start := p.pt
 		p.read()
+		p.failAt(true, start.position, ".")
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, p.pt.position, ".")
 	return nil, false
 }
 
@@ -2804,11 +2848,12 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	}
 
 	cur := p.pt.rn
+	start := p.pt
 	// can't match EOF
 	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
-	start := p.pt
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}
@@ -2817,9 +2862,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, rn := range chr.chars {
 		if rn == cur {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -2828,9 +2875,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for i := 0; i < len(chr.ranges); i += 2 {
 		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -2839,17 +2888,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, cl := range chr.classes {
 		if unicode.Is(cl, cur) {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
 
 	if chr.inverted {
 		p.read()
+		p.failAt(true, start.position, chr.val)
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, start.position, chr.val)
 	return nil, false
 }
 
@@ -2889,6 +2942,11 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -2896,12 +2954,33 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
+			p.failAt(false, start.position, val)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
+	p.failAt(true, start.position, val)
 	return p.sliceFrom(start), true
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if p.failureTracking && fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = make(map[string]struct{})
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected[want] = struct{}{}
+	}
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
@@ -2923,7 +3002,9 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 
 	pt := p.pt
 	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
 	p.restore(pt)
 	return nil, !ok

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2174,9 +2174,6 @@ var (
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
-
-	// errNoMatch is returned if no match could be found.
-	errNoMatch = errors.New("no match found")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -2220,19 +2217,6 @@ func Recover(b bool) Option {
 		old := p.recover
 		p.recover = b
 		return Recover(old)
-	}
-}
-
-// FailureTracking creates an Option to set failureTracking flag to b.
-// When set to true, this causes the parser to track the farthest failures
-// and report them, if the parsing of the input fails.
-//
-// The default is false.
-func FailureTracking(b bool) Option {
-	return func(p *parser) Option {
-		old := p.failureTracking
-		p.failureTracking = b
-		return FailureTracking(old)
 	}
 }
 
@@ -2482,7 +2466,6 @@ type parser struct {
 	exprCnt int
 
 	// parse fail
-	failureTracking       bool
 	maxFailPos            position
 	maxFailExpected       map[string]struct{}
 	maxFailInvertExpected bool
@@ -2668,28 +2651,23 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			if p.failureTracking {
-				// If parsing fails, but no errors have been recorded, the expected values
-				// for the farthest parser position are returned as error.
-				var expected []string
-				eof := ""
-				if _, ok := p.maxFailExpected["!."]; ok {
-					delete(p.maxFailExpected, "!.")
-					if len(p.maxFailExpected) > 0 {
-						eof = " or EOF"
-					} else {
-						eof = "EOF"
-					}
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			var expected []string
+			eof := ""
+			if _, ok := p.maxFailExpected["!."]; ok {
+				delete(p.maxFailExpected, "!.")
+				if len(p.maxFailExpected) > 0 {
+					eof = " or EOF"
+				} else {
+					eof = "EOF"
 				}
-				for k := range p.maxFailExpected {
-					expected = append(expected, k)
-				}
-				sort.Strings(expected)
-				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
-			} else {
-				// make sure this doesn't go out silently
-				p.addErr(errNoMatch)
 			}
+			for k := range p.maxFailExpected {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
 		}
 		return nil, p.errs.err()
 	}
@@ -2966,7 +2944,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 
 func (p *parser) failAt(fail bool, pos position, want string) {
 	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
-	if p.failureTracking && fail == p.maxFailInvertExpected {
+	if fail == p.maxFailInvertExpected {
 		if pos.offset < p.maxFailPos.offset {
 			return
 		}

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -8,9 +8,6 @@ var (
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
-
-	// errNoMatch is returned if no match could be found.
-	errNoMatch         = errors.New("no match found")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -54,19 +51,6 @@ func Recover(b bool) Option {
 		old := p.recover
 		p.recover = b
 		return Recover(old)
-	}
-}
-
-// FailureTracking creates an Option to set failureTracking flag to b.
-// When set to true, this causes the parser to track the farthest failures
-// and report them, if the parsing of the input fails.
-//
-// The default is false.
-func FailureTracking(b bool) Option {
-	return func(p *parser) Option {
-		old := p.failureTracking
-		p.failureTracking = b
-		return FailureTracking(old)
 	}
 }
 
@@ -316,7 +300,6 @@ type parser struct {
 	exprCnt int
 
 	// parse fail
-	failureTracking       bool
 	maxFailPos            position
 	maxFailExpected       map[string]struct{}
 	maxFailInvertExpected bool
@@ -502,28 +485,23 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			if p.failureTracking {
-				// If parsing fails, but no errors have been recorded, the expected values
-				// for the farthest parser position are returned as error.
-				var expected []string
-				eof := ""
-				if _, ok := p.maxFailExpected["!."]; ok {
-					delete(p.maxFailExpected, "!.")
-					if len(p.maxFailExpected) > 0 {
-						eof = " or EOF"
-					} else {
-						eof = "EOF"
-					}
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			var expected []string
+			eof := ""
+			if _, ok := p.maxFailExpected["!."]; ok {
+				delete(p.maxFailExpected, "!.")
+				if len(p.maxFailExpected) > 0 {
+					eof = " or EOF"
+				} else {
+					eof = "EOF"
 				}
-				for k := range p.maxFailExpected {
-					expected = append(expected, k)
-				}
-				sort.Strings(expected)
-				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
-			} else {
-				// make sure this doesn't go out silently
-				p.addErr(errNoMatch)
 			}
+			for k := range p.maxFailExpected {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
 		}
 		return nil, p.errs.err()
 	}
@@ -800,7 +778,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 
 func (p *parser) failAt(fail bool, pos position, want string) {
 	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
-	if p.failureTracking && fail == p.maxFailInvertExpected {
+	if fail == p.maxFailInvertExpected {
 		if pos.offset < p.maxFailPos.offset {
 			return
 		}

--- a/doc.go
+++ b/doc.go
@@ -295,7 +295,6 @@ as a package with public functions to parse input text. The exported API is:
 	- Debug(bool) Option
 	- Memoize(bool) Option
 	- Recover(bool) Option
-	- FailureTracking(bool) Option
 
 See the godoc page of the generated parser for the test/predicates grammar
 for an example documentation page of the exported API:
@@ -376,10 +375,6 @@ In order to do this, the grammar can look something like this:
 
 This is just one example, but it illustrates the idea that error reporting
 needs to be thought out when designing the grammar.
-
-By providing the FailureTracking(true) Option, the parser will keep track of the
-failed matches and provide the farthest failed parsing position as the error,
-which in most cases provides a reasonable error message.
 
 API stability
 

--- a/doc.go
+++ b/doc.go
@@ -295,6 +295,7 @@ as a package with public functions to parse input text. The exported API is:
 	- Debug(bool) Option
 	- Memoize(bool) Option
 	- Recover(bool) Option
+	- FailureTracking(bool) Option
 
 See the godoc page of the generated parser for the test/predicates grammar
 for an example documentation page of the exported API:
@@ -375,6 +376,10 @@ In order to do this, the grammar can look something like this:
 
 This is just one example, but it illustrates the idea that error reporting
 needs to be thought out when designing the grammar.
+
+By providing the FailureTracking(true) Option, the parser will keep track of the
+failed matches and provide the farthest failed parsing position as the error,
+which in most cases provides a reasonable error message.
 
 API stability
 

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -452,9 +452,6 @@ var (
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
-
-	// errNoMatch is returned if no match could be found.
-	errNoMatch = errors.New("no match found")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -498,19 +495,6 @@ func Recover(b bool) Option {
 		old := p.recover
 		p.recover = b
 		return Recover(old)
-	}
-}
-
-// FailureTracking creates an Option to set failureTracking flag to b.
-// When set to true, this causes the parser to track the farthest failures
-// and report them, if the parsing of the input fails.
-//
-// The default is false.
-func FailureTracking(b bool) Option {
-	return func(p *parser) Option {
-		old := p.failureTracking
-		p.failureTracking = b
-		return FailureTracking(old)
 	}
 }
 
@@ -760,7 +744,6 @@ type parser struct {
 	exprCnt int
 
 	// parse fail
-	failureTracking       bool
 	maxFailPos            position
 	maxFailExpected       map[string]struct{}
 	maxFailInvertExpected bool
@@ -946,28 +929,23 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			if p.failureTracking {
-				// If parsing fails, but no errors have been recorded, the expected values
-				// for the farthest parser position are returned as error.
-				var expected []string
-				eof := ""
-				if _, ok := p.maxFailExpected["!."]; ok {
-					delete(p.maxFailExpected, "!.")
-					if len(p.maxFailExpected) > 0 {
-						eof = " or EOF"
-					} else {
-						eof = "EOF"
-					}
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			var expected []string
+			eof := ""
+			if _, ok := p.maxFailExpected["!."]; ok {
+				delete(p.maxFailExpected, "!.")
+				if len(p.maxFailExpected) > 0 {
+					eof = " or EOF"
+				} else {
+					eof = "EOF"
 				}
-				for k := range p.maxFailExpected {
-					expected = append(expected, k)
-				}
-				sort.Strings(expected)
-				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
-			} else {
-				// make sure this doesn't go out silently
-				p.addErr(errNoMatch)
 			}
+			for k := range p.maxFailExpected {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
 		}
 		return nil, p.errs.err()
 	}
@@ -1244,7 +1222,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 
 func (p *parser) failAt(fail bool, pos position, want string) {
 	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
-	if p.failureTracking && fail == p.maxFailInvertExpected {
+	if fail == p.maxFailInvertExpected {
 		if pos.offset < p.maxFailPos.offset {
 			return
 		}

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -500,6 +501,19 @@ func Recover(b bool) Option {
 	}
 }
 
+// FailureTracking creates an Option to set failureTracking flag to b.
+// When set to true, this causes the parser to track the farthest failures
+// and report them, if the parsing of the input fails.
+//
+// The default is false.
+func FailureTracking(b bool) Option {
+	return func(p *parser) Option {
+		old := p.failureTracking
+		p.failureTracking = b
+		return FailureTracking(old)
+	}
+}
+
 // ParseFile parses the file identified by filename.
 func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 	f, err := os.Open(filename)
@@ -693,11 +707,13 @@ func (p *parserError) Error() string {
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
 	p := &parser{
-		filename: filename,
-		errs:     new(errList),
-		data:     b,
-		pt:       savepoint{position: position{line: 1}},
-		recover:  true,
+		filename:        filename,
+		errs:            new(errList),
+		data:            b,
+		pt:              savepoint{position: position{line: 1}},
+		recover:         true,
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make(map[string]struct{}),
 	}
 	p.setOptions(opts)
 	return p
@@ -742,6 +758,12 @@ type parser struct {
 
 	// stats
 	exprCnt int
+
+	// parse fail
+	failureTracking       bool
+	maxFailPos            position
+	maxFailExpected       map[string]struct{}
+	maxFailInvertExpected bool
 }
 
 // push a variable set on the vstack.
@@ -924,8 +946,28 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			// make sure this doesn't go out silently
-			p.addErr(errNoMatch)
+			if p.failureTracking {
+				// If parsing fails, but no errors have been recorded, the expected values
+				// for the farthest parser position are returned as error.
+				var expected []string
+				eof := ""
+				if _, ok := p.maxFailExpected["!."]; ok {
+					delete(p.maxFailExpected, "!.")
+					if len(p.maxFailExpected) > 0 {
+						eof = " or EOF"
+					} else {
+						eof = "EOF"
+					}
+				}
+				for k := range p.maxFailExpected {
+					expected = append(expected, k)
+				}
+				sort.Strings(expected)
+				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
+			} else {
+				// make sure this doesn't go out silently
+				p.addErr(errNoMatch)
+			}
 		}
 		return nil, p.errs.err()
 	}
@@ -1071,8 +1113,10 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	if p.pt.rn != utf8.RuneError {
 		start := p.pt
 		p.read()
+		p.failAt(true, start.position, ".")
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, p.pt.position, ".")
 	return nil, false
 }
 
@@ -1082,11 +1126,12 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	}
 
 	cur := p.pt.rn
+	start := p.pt
 	// can't match EOF
 	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
-	start := p.pt
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}
@@ -1095,9 +1140,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, rn := range chr.chars {
 		if rn == cur {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -1106,9 +1153,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for i := 0; i < len(chr.ranges); i += 2 {
 		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -1117,17 +1166,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, cl := range chr.classes {
 		if unicode.Is(cl, cur) {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
 
 	if chr.inverted {
 		p.read()
+		p.failAt(true, start.position, chr.val)
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, start.position, chr.val)
 	return nil, false
 }
 
@@ -1167,6 +1220,11 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1174,12 +1232,33 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
+			p.failAt(false, start.position, val)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
+	p.failAt(true, start.position, val)
 	return p.sliceFrom(start), true
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if p.failureTracking && fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = make(map[string]struct{})
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected[want] = struct{}{}
+	}
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
@@ -1201,7 +1280,9 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 
 	pt := p.pt
 	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
 	p.restore(pt)
 	return nil, !ok

--- a/examples/calculator/calculator_test.go
+++ b/examples/calculator/calculator_test.go
@@ -86,25 +86,62 @@ var invalidCases = map[string]string{
 	"\xfe":    "1:1 (0): invalid encoding",
 }
 
+var invalidCasesFailureTracking = map[string]string{
+	"":        `1:1 (0): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"(":       `1:2 (1): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	")":       `1:1 (0): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"()":      `1:2 (1): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"+":       `1:1 (0): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"-":       `1:2 (1): no match found, expected: [0-9]`,
+	"*":       `1:1 (0): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"/":       `1:1 (0): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"+1":      `1:1 (0): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"*1":      `1:1 (0): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"/1":      `1:1 (0): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"1+":      `1:3 (2): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"1-":      `1:3 (2): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"1*":      `1:3 (2): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"1/":      `1:3 (2): no match found, expected: "(", "-", [ \n\t\r], [0-9]`,
+	"1 (+ 2)": `1:3 (2): no match found, expected: "*", "+", "-", "/", [ \n\t\r] or EOF`,
+	"1 (2)":   `1:3 (2): no match found, expected: "*", "+", "-", "/", [ \n\t\r] or EOF`,
+}
+
 func TestInvalidCases(t *testing.T) {
-	for tc, exp := range invalidCases {
-		got, err := Parse("", []byte(tc))
-		if err == nil {
-			t.Errorf("%q: want error, got none (%v)", tc, got)
-			continue
-		}
-		el, ok := err.(errList)
-		if !ok {
-			t.Errorf("%q: want error type %T, got %T", tc, &errList{}, err)
-			continue
-		}
-		for _, e := range el {
-			if _, ok := e.(*parserError); !ok {
-				t.Errorf("%q: want all individual errors to be %T, got %T (%[3]v)", tc, &parserError{}, e)
+	config := []struct {
+		failureTracking bool
+	}{
+		{
+			failureTracking: false,
+		},
+		{
+			failureTracking: true,
+		},
+	}
+	for _, conf := range config {
+		for tc, exp := range invalidCases {
+			got, err := Parse("", []byte(tc), FailureTracking(conf.failureTracking))
+			if err == nil {
+				t.Errorf("%q: want error, got none (%v)", tc, got)
+				continue
 			}
-		}
-		if exp != err.Error() {
-			t.Errorf("%q: want \n%s\n, got \n%s\n", tc, exp, err)
+			el, ok := err.(errList)
+			if !ok {
+				t.Errorf("%q: want error type %T, got %T", tc, &errList{}, err)
+				continue
+			}
+			for _, e := range el {
+				if _, ok := e.(*parserError); !ok {
+					t.Errorf("%q: want all individual errors to be %T, got %T (%[3]v)", tc, &parserError{}, e)
+				}
+			}
+			if conf.failureTracking {
+				if failTrackExp, ok := invalidCasesFailureTracking[tc]; ok {
+					exp = failTrackExp
+				}
+			}
+			if exp != err.Error() {
+				t.Errorf("%q: want \n%s\n, got \n%s\n", tc, exp, err)
+			}
 		}
 	}
 }

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -772,9 +772,6 @@ var (
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
-
-	// errNoMatch is returned if no match could be found.
-	errNoMatch = errors.New("no match found")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -818,19 +815,6 @@ func Recover(b bool) Option {
 		old := p.recover
 		p.recover = b
 		return Recover(old)
-	}
-}
-
-// FailureTracking creates an Option to set failureTracking flag to b.
-// When set to true, this causes the parser to track the farthest failures
-// and report them, if the parsing of the input fails.
-//
-// The default is false.
-func FailureTracking(b bool) Option {
-	return func(p *parser) Option {
-		old := p.failureTracking
-		p.failureTracking = b
-		return FailureTracking(old)
 	}
 }
 
@@ -1080,7 +1064,6 @@ type parser struct {
 	exprCnt int
 
 	// parse fail
-	failureTracking       bool
 	maxFailPos            position
 	maxFailExpected       map[string]struct{}
 	maxFailInvertExpected bool
@@ -1266,28 +1249,23 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			if p.failureTracking {
-				// If parsing fails, but no errors have been recorded, the expected values
-				// for the farthest parser position are returned as error.
-				var expected []string
-				eof := ""
-				if _, ok := p.maxFailExpected["!."]; ok {
-					delete(p.maxFailExpected, "!.")
-					if len(p.maxFailExpected) > 0 {
-						eof = " or EOF"
-					} else {
-						eof = "EOF"
-					}
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			var expected []string
+			eof := ""
+			if _, ok := p.maxFailExpected["!."]; ok {
+				delete(p.maxFailExpected, "!.")
+				if len(p.maxFailExpected) > 0 {
+					eof = " or EOF"
+				} else {
+					eof = "EOF"
 				}
-				for k := range p.maxFailExpected {
-					expected = append(expected, k)
-				}
-				sort.Strings(expected)
-				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
-			} else {
-				// make sure this doesn't go out silently
-				p.addErr(errNoMatch)
 			}
+			for k := range p.maxFailExpected {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
 		}
 		return nil, p.errs.err()
 	}
@@ -1564,7 +1542,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 
 func (p *parser) failAt(fail bool, pos position, want string) {
 	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
-	if p.failureTracking && fail == p.maxFailInvertExpected {
+	if fail == p.maxFailInvertExpected {
 		if pos.offset < p.maxFailPos.offset {
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 		outputFlag    = fs.String("o", "", "output file, defaults to stdout")
 		recvrNmFlag   = fs.String("receiver-name", "c", "receiver name for the generated methods")
 		noBuildFlag   = fs.Bool("x", false, "do not build, only parse")
+		trackFailFlag = fs.Bool("track-fail", false, "track farthest position of parsing failures to generate meaningful error messages")
 	)
 
 	fs.Usage = usage
@@ -70,7 +71,7 @@ func main() {
 	}()
 
 	// parse input
-	g, err := ParseReader(nm, rc, Debug(*dbgFlag), Memoize(*cacheFlag), Recover(!*noRecoverFlag))
+	g, err := ParseReader(nm, rc, Debug(*dbgFlag), Memoize(*cacheFlag), Recover(!*noRecoverFlag), FailureTracking(*trackFailFlag))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "parse error(s):\n", err)
 		exit(3)
@@ -141,6 +142,9 @@ the generated code is written to this file instead.
 	-receiver-name NAME
 		use NAME as for the receiver name of the generated methods
 		for the grammar's code blocks. Defaults to "c".
+	-track-fail
+		track farthest position of parsing failures to generate 
+		meaningful error messages
 	-x
 		do not generate the parser, only parse the grammar.
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ func main() {
 		outputFlag    = fs.String("o", "", "output file, defaults to stdout")
 		recvrNmFlag   = fs.String("receiver-name", "c", "receiver name for the generated methods")
 		noBuildFlag   = fs.Bool("x", false, "do not build, only parse")
-		trackFailFlag = fs.Bool("track-fail", false, "track farthest position of parsing failures to generate meaningful error messages")
 	)
 
 	fs.Usage = usage
@@ -71,7 +70,7 @@ func main() {
 	}()
 
 	// parse input
-	g, err := ParseReader(nm, rc, Debug(*dbgFlag), Memoize(*cacheFlag), Recover(!*noRecoverFlag), FailureTracking(*trackFailFlag))
+	g, err := ParseReader(nm, rc, Debug(*dbgFlag), Memoize(*cacheFlag), Recover(!*noRecoverFlag))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "parse error(s):\n", err)
 		exit(3)

--- a/parse_test.go
+++ b/parse_test.go
@@ -167,22 +167,53 @@ file:1:26 (25): rule ShortUnicodeEscape: invalid Unicode escape`,
 	`a = "\U0000D801"`: "file:1:7 (6): rule LongUnicodeEscape: invalid Unicode escape",
 }
 
+var invalidParseCasesFailureTracking = map[string]string{
+	"":           `file:1:1 (0): no match found, expected: "/*", "//", "\n", "{", [ \t\r], [\pL_]`,
+	"a":          `file:1:2 (1): no match found, expected: "'", "/*", "//", "<-", "=", "\"", "\n", "` + "`" + `", "←", "⟵", [ \t\r], [\pL_], [\p{Nd}]`,
+	"abc":        `file:1:4 (3): no match found, expected: "'", "/*", "//", "<-", "=", "\"", "\n", "` + "`" + `", "←", "⟵", [ \t\r], [\pL_], [\p{Nd}]`,
+	" ":          `file:1:2 (1): no match found, expected: "/*", "//", "\n", "{", [ \t\r], [\pL_]`,
+	`a = +`:      `file:1:5 (4): no match found, expected: "!", "&", "'", "(", ".", "/*", "//", "[", "\"", "\n", "` + "`" + `", [ \t\r], [\pL_]`,
+	`a = *`:      `file:1:5 (4): no match found, expected: "!", "&", "'", "(", ".", "/*", "//", "[", "\"", "\n", "` + "`" + `", [ \t\r], [\pL_]`,
+	`a = ?`:      `file:1:5 (4): no match found, expected: "!", "&", "'", "(", ".", "/*", "//", "[", "\"", "\n", "` + "`" + `", [ \t\r], [\pL_]`,
+	"a ←":        `file:1:4 (5): no match found, expected: "!", "&", "'", "(", ".", "/*", "//", "[", "\"", "\n", "` + "`" + `", [ \t\r], [\pL_]`,
+	"a ← b\nb ←": `file:2:4 (13): no match found, expected: "!", "&", "'", "(", ".", "/*", "//", "[", "\"", "\n", "` + "`" + `", [ \t\r], [\pL_]`,
+	"{}{}":       `file:1:3 (2): no match found, expected: "/*", "//", ";", "\n", [ \t\r] or EOF`,
+}
+
 func TestInvalidParseCases(t *testing.T) {
-	memo := false
-again:
-	for tc, exp := range invalidParseCases {
-		_, err := Parse("file", []byte(tc), Memoize(memo))
-		if err == nil {
-			t.Errorf("%q: want error, got none", tc)
-			continue
-		}
-		if err.Error() != exp {
-			t.Errorf("%q: want \n%s\n, got \n%s\n", tc, exp, err)
-		}
+	config := []struct {
+		memoize         bool
+		failureTracking bool
+	}{
+		{
+			memoize:         false,
+			failureTracking: false,
+		},
+		{
+			memoize:         true,
+			failureTracking: false,
+		},
+		{
+			memoize:         false,
+			failureTracking: true,
+		},
 	}
-	if !memo {
-		memo = true
-		goto again
+	for _, conf := range config {
+		for tc, exp := range invalidParseCases {
+			_, err := Parse("file", []byte(tc), Memoize(conf.memoize), FailureTracking(conf.failureTracking))
+			if err == nil {
+				t.Errorf("%q: want error, got none", tc)
+				continue
+			}
+			if conf.failureTracking {
+				if failTrackExp, ok := invalidParseCasesFailureTracking[tc]; ok {
+					exp = failTrackExp
+				}
+			}
+			if err.Error() != exp {
+				t.Errorf("%q: want \n%s\n, got \n%s\n", tc, exp, err)
+			}
+		}
 	}
 }
 

--- a/pigeon.go
+++ b/pigeon.go
@@ -2841,9 +2841,6 @@ var (
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
-
-	// errNoMatch is returned if no match could be found.
-	errNoMatch = errors.New("no match found")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -2887,19 +2884,6 @@ func Recover(b bool) Option {
 		old := p.recover
 		p.recover = b
 		return Recover(old)
-	}
-}
-
-// FailureTracking creates an Option to set failureTracking flag to b.
-// When set to true, this causes the parser to track the farthest failures
-// and report them, if the parsing of the input fails.
-//
-// The default is false.
-func FailureTracking(b bool) Option {
-	return func(p *parser) Option {
-		old := p.failureTracking
-		p.failureTracking = b
-		return FailureTracking(old)
 	}
 }
 
@@ -3149,7 +3133,6 @@ type parser struct {
 	exprCnt int
 
 	// parse fail
-	failureTracking       bool
 	maxFailPos            position
 	maxFailExpected       map[string]struct{}
 	maxFailInvertExpected bool
@@ -3335,28 +3318,23 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			if p.failureTracking {
-				// If parsing fails, but no errors have been recorded, the expected values
-				// for the farthest parser position are returned as error.
-				var expected []string
-				eof := ""
-				if _, ok := p.maxFailExpected["!."]; ok {
-					delete(p.maxFailExpected, "!.")
-					if len(p.maxFailExpected) > 0 {
-						eof = " or EOF"
-					} else {
-						eof = "EOF"
-					}
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			var expected []string
+			eof := ""
+			if _, ok := p.maxFailExpected["!."]; ok {
+				delete(p.maxFailExpected, "!.")
+				if len(p.maxFailExpected) > 0 {
+					eof = " or EOF"
+				} else {
+					eof = "EOF"
 				}
-				for k := range p.maxFailExpected {
-					expected = append(expected, k)
-				}
-				sort.Strings(expected)
-				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
-			} else {
-				// make sure this doesn't go out silently
-				p.addErr(errNoMatch)
 			}
+			for k := range p.maxFailExpected {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
 		}
 		return nil, p.errs.err()
 	}
@@ -3633,7 +3611,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 
 func (p *parser) failAt(fail bool, pos position, want string) {
 	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
-	if p.failureTracking && fail == p.maxFailInvertExpected {
+	if fail == p.maxFailInvertExpected {
 		if pos.offset < p.maxFailPos.offset {
 			return
 		}

--- a/pigeon.go
+++ b/pigeon.go
@@ -2899,7 +2899,7 @@ func FailureTracking(b bool) Option {
 	return func(p *parser) Option {
 		old := p.failureTracking
 		p.failureTracking = b
-		return Recover(old)
+		return FailureTracking(old)
 	}
 }
 

--- a/pigeon.go
+++ b/pigeon.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -2889,6 +2890,19 @@ func Recover(b bool) Option {
 	}
 }
 
+// FailureTracking creates an Option to set failureTracking flag to b.
+// When set to true, this causes the parser to track the farthest failures
+// and report them, if the parsing of the input fails.
+//
+// The default is false.
+func FailureTracking(b bool) Option {
+	return func(p *parser) Option {
+		old := p.failureTracking
+		p.failureTracking = b
+		return Recover(old)
+	}
+}
+
 // ParseFile parses the file identified by filename.
 func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 	f, err := os.Open(filename)
@@ -3082,11 +3096,13 @@ func (p *parserError) Error() string {
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
 	p := &parser{
-		filename: filename,
-		errs:     new(errList),
-		data:     b,
-		pt:       savepoint{position: position{line: 1}},
-		recover:  true,
+		filename:        filename,
+		errs:            new(errList),
+		data:            b,
+		pt:              savepoint{position: position{line: 1}},
+		recover:         true,
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make(map[string]struct{}),
 	}
 	p.setOptions(opts)
 	return p
@@ -3131,6 +3147,12 @@ type parser struct {
 
 	// stats
 	exprCnt int
+
+	// parse fail
+	failureTracking       bool
+	maxFailPos            position
+	maxFailExpected       map[string]struct{}
+	maxFailInvertExpected bool
 }
 
 // push a variable set on the vstack.
@@ -3313,8 +3335,28 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			// make sure this doesn't go out silently
-			p.addErr(errNoMatch)
+			if p.failureTracking {
+				// If parsing fails, but no errors have been recorded, the expected values
+				// for the farthest parser position are returned as error.
+				var expected []string
+				eof := ""
+				if _, ok := p.maxFailExpected["!."]; ok {
+					delete(p.maxFailExpected, "!.")
+					if len(p.maxFailExpected) > 0 {
+						eof = " or EOF"
+					} else {
+						eof = "EOF"
+					}
+				}
+				for k := range p.maxFailExpected {
+					expected = append(expected, k)
+				}
+				sort.Strings(expected)
+				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
+			} else {
+				// make sure this doesn't go out silently
+				p.addErr(errNoMatch)
+			}
 		}
 		return nil, p.errs.err()
 	}
@@ -3460,8 +3502,10 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	if p.pt.rn != utf8.RuneError {
 		start := p.pt
 		p.read()
+		p.failAt(true, start.position, ".")
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, p.pt.position, ".")
 	return nil, false
 }
 
@@ -3471,11 +3515,12 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	}
 
 	cur := p.pt.rn
+	start := p.pt
 	// can't match EOF
 	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
-	start := p.pt
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}
@@ -3484,9 +3529,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, rn := range chr.chars {
 		if rn == cur {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -3495,9 +3542,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for i := 0; i < len(chr.ranges); i += 2 {
 		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -3506,17 +3555,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, cl := range chr.classes {
 		if unicode.Is(cl, cur) {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
 
 	if chr.inverted {
 		p.read()
+		p.failAt(true, start.position, chr.val)
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, start.position, chr.val)
 	return nil, false
 }
 
@@ -3556,6 +3609,11 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -3563,12 +3621,33 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
+			p.failAt(false, start.position, val)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
+	p.failAt(true, start.position, val)
 	return p.sliceFrom(start), true
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if p.failureTracking && fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = make(map[string]struct{})
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected[want] = struct{}{}
+	}
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
@@ -3590,7 +3669,9 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 
 	pt := p.pt
 	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
 	p.restore(pt)
 	return nil, !ok

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -231,6 +232,19 @@ func Recover(b bool) Option {
 	}
 }
 
+// FailureTracking creates an Option to set failureTracking flag to b.
+// When set to true, this causes the parser to track the farthest failures
+// and report them, if the parsing of the input fails.
+//
+// The default is false.
+func FailureTracking(b bool) Option {
+	return func(p *parser) Option {
+		old := p.failureTracking
+		p.failureTracking = b
+		return FailureTracking(old)
+	}
+}
+
 // ParseFile parses the file identified by filename.
 func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 	f, err := os.Open(filename)
@@ -424,11 +438,13 @@ func (p *parserError) Error() string {
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
 	p := &parser{
-		filename: filename,
-		errs:     new(errList),
-		data:     b,
-		pt:       savepoint{position: position{line: 1}},
-		recover:  true,
+		filename:        filename,
+		errs:            new(errList),
+		data:            b,
+		pt:              savepoint{position: position{line: 1}},
+		recover:         true,
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make(map[string]struct{}),
 	}
 	p.setOptions(opts)
 	return p
@@ -473,6 +489,12 @@ type parser struct {
 
 	// stats
 	exprCnt int
+
+	// parse fail
+	failureTracking       bool
+	maxFailPos            position
+	maxFailExpected       map[string]struct{}
+	maxFailInvertExpected bool
 }
 
 // push a variable set on the vstack.
@@ -655,8 +677,28 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			// make sure this doesn't go out silently
-			p.addErr(errNoMatch)
+			if p.failureTracking {
+				// If parsing fails, but no errors have been recorded, the expected values
+				// for the farthest parser position are returned as error.
+				var expected []string
+				eof := ""
+				if _, ok := p.maxFailExpected["!."]; ok {
+					delete(p.maxFailExpected, "!.")
+					if len(p.maxFailExpected) > 0 {
+						eof = " or EOF"
+					} else {
+						eof = "EOF"
+					}
+				}
+				for k := range p.maxFailExpected {
+					expected = append(expected, k)
+				}
+				sort.Strings(expected)
+				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
+			} else {
+				// make sure this doesn't go out silently
+				p.addErr(errNoMatch)
+			}
 		}
 		return nil, p.errs.err()
 	}
@@ -802,8 +844,10 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	if p.pt.rn != utf8.RuneError {
 		start := p.pt
 		p.read()
+		p.failAt(true, start.position, ".")
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, p.pt.position, ".")
 	return nil, false
 }
 
@@ -813,11 +857,12 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	}
 
 	cur := p.pt.rn
+	start := p.pt
 	// can't match EOF
 	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
-	start := p.pt
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}
@@ -826,9 +871,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, rn := range chr.chars {
 		if rn == cur {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -837,9 +884,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for i := 0; i < len(chr.ranges); i += 2 {
 		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -848,17 +897,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, cl := range chr.classes {
 		if unicode.Is(cl, cur) {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
 
 	if chr.inverted {
 		p.read()
+		p.failAt(true, start.position, chr.val)
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, start.position, chr.val)
 	return nil, false
 }
 
@@ -898,6 +951,11 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -905,12 +963,33 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
+			p.failAt(false, start.position, val)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
+	p.failAt(true, start.position, val)
 	return p.sliceFrom(start), true
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if p.failureTracking && fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = make(map[string]struct{})
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected[want] = struct{}{}
+	}
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
@@ -932,7 +1011,9 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 
 	pt := p.pt
 	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
 	p.restore(pt)
 	return nil, !ok

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -183,9 +183,6 @@ var (
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
-
-	// errNoMatch is returned if no match could be found.
-	errNoMatch = errors.New("no match found")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -229,19 +226,6 @@ func Recover(b bool) Option {
 		old := p.recover
 		p.recover = b
 		return Recover(old)
-	}
-}
-
-// FailureTracking creates an Option to set failureTracking flag to b.
-// When set to true, this causes the parser to track the farthest failures
-// and report them, if the parsing of the input fails.
-//
-// The default is false.
-func FailureTracking(b bool) Option {
-	return func(p *parser) Option {
-		old := p.failureTracking
-		p.failureTracking = b
-		return FailureTracking(old)
 	}
 }
 
@@ -491,7 +475,6 @@ type parser struct {
 	exprCnt int
 
 	// parse fail
-	failureTracking       bool
 	maxFailPos            position
 	maxFailExpected       map[string]struct{}
 	maxFailInvertExpected bool
@@ -677,28 +660,23 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			if p.failureTracking {
-				// If parsing fails, but no errors have been recorded, the expected values
-				// for the farthest parser position are returned as error.
-				var expected []string
-				eof := ""
-				if _, ok := p.maxFailExpected["!."]; ok {
-					delete(p.maxFailExpected, "!.")
-					if len(p.maxFailExpected) > 0 {
-						eof = " or EOF"
-					} else {
-						eof = "EOF"
-					}
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			var expected []string
+			eof := ""
+			if _, ok := p.maxFailExpected["!."]; ok {
+				delete(p.maxFailExpected, "!.")
+				if len(p.maxFailExpected) > 0 {
+					eof = " or EOF"
+				} else {
+					eof = "EOF"
 				}
-				for k := range p.maxFailExpected {
-					expected = append(expected, k)
-				}
-				sort.Strings(expected)
-				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
-			} else {
-				// make sure this doesn't go out silently
-				p.addErr(errNoMatch)
 			}
+			for k := range p.maxFailExpected {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
 		}
 		return nil, p.errs.err()
 	}
@@ -975,7 +953,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 
 func (p *parser) failAt(fail bool, pos position, want string) {
 	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
-	if p.failureTracking && fail == p.maxFailInvertExpected {
+	if fail == p.maxFailInvertExpected {
 		if pos.offset < p.maxFailPos.offset {
 			return
 		}

--- a/test/andnot/andnot_test.go
+++ b/test/andnot/andnot_test.go
@@ -22,15 +22,44 @@ var cases = map[string]string{
 	"dcddccdd":     "",
 }
 
+var casesFailureTracking = map[string]string{
+	"":        `1:1 (0): no match found, expected: [ \t\n\r], [ab], [cd]`,
+	"a":       `1:2 (1): no match found, expected: [ab]`,
+	"ba":      `1:3 (2): no match found, expected: [ab]`,
+	"bba":     `1:4 (3): no match found, expected: [ab]`,
+	"aabbaba": `1:8 (7): no match found, expected: [ab]`,
+	"abc":     `1:3 (2): no match found, expected: [ \t\n\r], [ab] or EOF`,
+	"c":       `1:2 (1): no match found, expected: [cd]`,
+	"dc":      `1:3 (2): no match found, expected: [cd]`,
+	"dcddcc":  `1:7 (6): no match found, expected: [cd]`,
+}
+
 func TestAndNot(t *testing.T) {
-	for tc, exp := range cases {
-		_, err := Parse("", []byte(tc))
-		var got string
-		if err != nil {
-			got = err.Error()
-		}
-		if got != exp {
-			t.Errorf("%q: want %v, got %v", tc, exp, got)
+	config := []struct {
+		failureTracking bool
+	}{
+		{
+			failureTracking: false,
+		},
+		{
+			failureTracking: true,
+		},
+	}
+	for _, conf := range config {
+		for tc, exp := range cases {
+			_, err := Parse("", []byte(tc), FailureTracking(conf.failureTracking))
+			var got string
+			if err != nil {
+				got = err.Error()
+			}
+			if conf.failureTracking {
+				if failTrackExp, ok := casesFailureTracking[tc]; ok {
+					exp = failTrackExp
+				}
+			}
+			if got != exp {
+				t.Errorf("%q: want %v, got %v", tc, exp, got)
+			}
 		}
 	}
 }

--- a/test/andnot/andnot_test.go
+++ b/test/andnot/andnot_test.go
@@ -4,62 +4,33 @@ import "testing"
 
 // ABs must end in Bs, CDs must end in Ds
 var cases = map[string]string{
-	"":             "1:1 (0): no match found",
-	"a":            "1:1 (0): no match found",
+	"":             `1:1 (0): no match found, expected: [ \t\n\r], [ab], [cd]`,
+	"a":            `1:2 (1): no match found, expected: [ab]`,
 	"b":            "",
 	"ab":           "",
-	"ba":           "1:1 (0): no match found",
+	"ba":           `1:3 (2): no match found, expected: [ab]`,
 	"aab":          "",
-	"bba":          "1:1 (0): no match found",
-	"aabbaba":      "1:1 (0): no match found",
+	"bba":          `1:4 (3): no match found, expected: [ab]`,
+	"aabbaba":      `1:8 (7): no match found, expected: [ab]`,
 	"bbaabaaabbbb": "",
-	"abc":          "1:1 (0): no match found",
-	"c":            "1:1 (0): no match found",
+	"abc":          `1:3 (2): no match found, expected: [ \t\n\r], [ab] or EOF`,
+	"c":            `1:2 (1): no match found, expected: [cd]`,
 	"d":            "",
 	"cd":           "",
-	"dc":           "1:1 (0): no match found",
-	"dcddcc":       "1:1 (0): no match found",
+	"dc":           `1:3 (2): no match found, expected: [cd]`,
+	"dcddcc":       `1:7 (6): no match found, expected: [cd]`,
 	"dcddccdd":     "",
 }
 
-var casesFailureTracking = map[string]string{
-	"":        `1:1 (0): no match found, expected: [ \t\n\r], [ab], [cd]`,
-	"a":       `1:2 (1): no match found, expected: [ab]`,
-	"ba":      `1:3 (2): no match found, expected: [ab]`,
-	"bba":     `1:4 (3): no match found, expected: [ab]`,
-	"aabbaba": `1:8 (7): no match found, expected: [ab]`,
-	"abc":     `1:3 (2): no match found, expected: [ \t\n\r], [ab] or EOF`,
-	"c":       `1:2 (1): no match found, expected: [cd]`,
-	"dc":      `1:3 (2): no match found, expected: [cd]`,
-	"dcddcc":  `1:7 (6): no match found, expected: [cd]`,
-}
-
 func TestAndNot(t *testing.T) {
-	config := []struct {
-		failureTracking bool
-	}{
-		{
-			failureTracking: false,
-		},
-		{
-			failureTracking: true,
-		},
-	}
-	for _, conf := range config {
-		for tc, exp := range cases {
-			_, err := Parse("", []byte(tc), FailureTracking(conf.failureTracking))
-			var got string
-			if err != nil {
-				got = err.Error()
-			}
-			if conf.failureTracking {
-				if failTrackExp, ok := casesFailureTracking[tc]; ok {
-					exp = failTrackExp
-				}
-			}
-			if got != exp {
-				t.Errorf("%q: want %v, got %v", tc, exp, got)
-			}
+	for tc, exp := range cases {
+		_, err := Parse("", []byte(tc))
+		var got string
+		if err != nil {
+			got = err.Error()
+		}
+		if got != exp {
+			t.Errorf("%q: want %v, got %v", tc, exp, got)
 		}
 	}
 }

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -581,9 +581,6 @@ var (
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
-
-	// errNoMatch is returned if no match could be found.
-	errNoMatch = errors.New("no match found")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -627,19 +624,6 @@ func Recover(b bool) Option {
 		old := p.recover
 		p.recover = b
 		return Recover(old)
-	}
-}
-
-// FailureTracking creates an Option to set failureTracking flag to b.
-// When set to true, this causes the parser to track the farthest failures
-// and report them, if the parsing of the input fails.
-//
-// The default is false.
-func FailureTracking(b bool) Option {
-	return func(p *parser) Option {
-		old := p.failureTracking
-		p.failureTracking = b
-		return FailureTracking(old)
 	}
 }
 
@@ -889,7 +873,6 @@ type parser struct {
 	exprCnt int
 
 	// parse fail
-	failureTracking       bool
 	maxFailPos            position
 	maxFailExpected       map[string]struct{}
 	maxFailInvertExpected bool
@@ -1075,28 +1058,23 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			if p.failureTracking {
-				// If parsing fails, but no errors have been recorded, the expected values
-				// for the farthest parser position are returned as error.
-				var expected []string
-				eof := ""
-				if _, ok := p.maxFailExpected["!."]; ok {
-					delete(p.maxFailExpected, "!.")
-					if len(p.maxFailExpected) > 0 {
-						eof = " or EOF"
-					} else {
-						eof = "EOF"
-					}
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			var expected []string
+			eof := ""
+			if _, ok := p.maxFailExpected["!."]; ok {
+				delete(p.maxFailExpected, "!.")
+				if len(p.maxFailExpected) > 0 {
+					eof = " or EOF"
+				} else {
+					eof = "EOF"
 				}
-				for k := range p.maxFailExpected {
-					expected = append(expected, k)
-				}
-				sort.Strings(expected)
-				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
-			} else {
-				// make sure this doesn't go out silently
-				p.addErr(errNoMatch)
 			}
+			for k := range p.maxFailExpected {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
 		}
 		return nil, p.errs.err()
 	}
@@ -1373,7 +1351,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 
 func (p *parser) failAt(fail bool, pos position, want string) {
 	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
-	if p.failureTracking && fail == p.maxFailInvertExpected {
+	if fail == p.maxFailInvertExpected {
 		if pos.offset < p.maxFailPos.offset {
 			return
 		}

--- a/test/errorpos/errorpos.peg
+++ b/test/errorpos/errorpos.peg
@@ -1,0 +1,25 @@
+{
+package errorpos
+}
+
+Input ← _ (case01 / case02 / case03 / case04 / case05 / case06 / case07 / case08 / case09 / case10 / case11) EOF
+
+case01 ← "case01" _ ((increment / decrement / zero) _ )+
+case02 ← "case02" __ [^abc]+
+case03 ← "case03" __ "x"? [0-9]
+case04 ← "case04" __ [\x30-\x39] [^\x30-\x39] [\pN] [^\pN]
+case05 ← "case05" __ !"not" "yes"
+case06 ← "case06" __ ![0-9] "x"
+case07 ← "case07" __ !("abc"i / [a-c]i / [\pL]) [0-9]
+case08 ← "case08" __ &"a"i .
+case09 ← "case09" __ &[0-9] .
+case10 ← "case10" __ &("0" / [012] / [3-9] / [\pN]) .
+case11 ← "case11" __ !(!("a")) "a"
+
+increment ← "inc"
+decrement ← "dec"
+zero ← "zero"
+oneOrMore ← "oneOrMore"
+_ ← [ \t\n\r]*
+__ ← [ ]
+EOF ← !.

--- a/test/errorpos/errorpos_test.go
+++ b/test/errorpos/errorpos_test.go
@@ -1,0 +1,55 @@
+package errorpos
+
+import "testing"
+
+// ABs must end in Bs, CDs must end in Ds
+var cases = map[string]string{
+	"case01 zero":           ``,
+	" case01 inc dec zero ": ``,
+	"":                `1:1 (0): no match found, expected: "case01", "case02", "case03", "case04", "case05", "case06", "case07", "case08", "case09", "case10", "case11", [ \t\n\r]`,
+	"kase01":          `1:1 (0): no match found, expected: "case01", "case02", "case03", "case04", "case05", "case06", "case07", "case08", "case09", "case10", "case11", [ \t\n\r]`,
+	"case01 zero ink": `1:13 (12): no match found, expected: "dec", "inc", "zero", [ \t\n\r] or EOF`,
+	"case02 xyz":      ``,
+	"case02 ":         `1:8 (7): no match found, expected: [^abc]`,
+	"case02xyz":       `1:7 (6): no match found, expected: [ ]`,
+	"case02 abc":      `1:8 (7): no match found, expected: [^abc]`,
+	"case02 xya":      `1:10 (9): no match found, expected: [^abc] or EOF`,
+	"case03 0":        ``,
+	"case03 x0":       ``,
+	"case03 y":        `1:8 (7): no match found, expected: "x", [0-9]`,
+	"case03 xy":       `1:9 (8): no match found, expected: [0-9]`,
+	"case03 10":       `1:9 (8): no match found, expected: EOF`,
+	"case04 0x0x":     ``,
+	"case04 x":        `1:8 (7): no match found, expected: [\x30-\x39]`,
+	"case04 00":       `1:9 (8): no match found, expected: [^\x30-\x39]`,
+	"case04 0xx":      `1:10 (9): no match found, expected: [\pN]`,
+	"case04 0x00":     `1:11 (10): no match found, expected: [^\pN]`,
+	"case05 yes":      ``,
+	"case05 not":      `1:8 (7): no match found, expected: !"not"`,
+	"case06 x":        ``,
+	"case06 0":        `1:8 (7): no match found, expected: ![0-9]`,
+	"case07 0":        ``,
+	"case07 a":        `1:8 (7): no match found, expected: ![a-c]i`,
+	"case08 a":        ``,
+	"case08 b":        `1:8 (7): no match found, expected: "a"i`,
+	"case09 0":        ``,
+	"case09 a":        `1:8 (7): no match found, expected: [0-9]`,
+	"case10 9":        ``,
+	"case10 x":        `1:8 (7): no match found, expected: "0", [012], [3-9], [\pN]`,
+	"case11 a":        ``,
+	"case11 b":        `1:8 (7): no match found, expected: "a"`,
+}
+
+func TestAndNot(t *testing.T) {
+	for tc, exp := range cases {
+		_, err := Parse("", []byte(tc), FailureTracking(true))
+		var got string
+		if err != nil {
+			got = err.Error()
+		}
+		if got != exp {
+			_, _ = Parse("", []byte(tc), FailureTracking(true), Debug(true))
+			t.Errorf("%q: want %v, got %v", tc, exp, got)
+		}
+	}
+}

--- a/test/errorpos/errorpos_test.go
+++ b/test/errorpos/errorpos_test.go
@@ -41,13 +41,13 @@ var cases = map[string]string{
 
 func TestErrorPos(t *testing.T) {
 	for tc, exp := range cases {
-		_, err := Parse("", []byte(tc), FailureTracking(true))
+		_, err := Parse("", []byte(tc))
 		var got string
 		if err != nil {
 			got = err.Error()
 		}
 		if got != exp {
-			_, _ = Parse("", []byte(tc), FailureTracking(true), Debug(true))
+			_, _ = Parse("", []byte(tc), Debug(true))
 			t.Errorf("%q: want %v, got %v", tc, exp, got)
 		}
 	}

--- a/test/errorpos/errorpos_test.go
+++ b/test/errorpos/errorpos_test.go
@@ -2,7 +2,6 @@ package errorpos
 
 import "testing"
 
-// ABs must end in Bs, CDs must end in Ds
 var cases = map[string]string{
 	"case01 zero":           ``,
 	" case01 inc dec zero ": ``,
@@ -40,7 +39,7 @@ var cases = map[string]string{
 	"case11 b":        `1:8 (7): no match found, expected: "a"`,
 }
 
-func TestAndNot(t *testing.T) {
+func TestErrorPos(t *testing.T) {
 	for tc, exp := range cases {
 		_, err := Parse("", []byte(tc), FailureTracking(true))
 		var got string

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -159,6 +160,19 @@ func Recover(b bool) Option {
 		old := p.recover
 		p.recover = b
 		return Recover(old)
+	}
+}
+
+// FailureTracking creates an Option to set failureTracking flag to b.
+// When set to true, this causes the parser to track the farthest failures
+// and report them, if the parsing of the input fails.
+//
+// The default is false.
+func FailureTracking(b bool) Option {
+	return func(p *parser) Option {
+		old := p.failureTracking
+		p.failureTracking = b
+		return FailureTracking(old)
 	}
 }
 
@@ -355,11 +369,13 @@ func (p *parserError) Error() string {
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
 	p := &parser{
-		filename: filename,
-		errs:     new(errList),
-		data:     b,
-		pt:       savepoint{position: position{line: 1}},
-		recover:  true,
+		filename:        filename,
+		errs:            new(errList),
+		data:            b,
+		pt:              savepoint{position: position{line: 1}},
+		recover:         true,
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make(map[string]struct{}),
 	}
 	p.setOptions(opts)
 	return p
@@ -404,6 +420,12 @@ type parser struct {
 
 	// stats
 	exprCnt int
+
+	// parse fail
+	failureTracking       bool
+	maxFailPos            position
+	maxFailExpected       map[string]struct{}
+	maxFailInvertExpected bool
 }
 
 // push a variable set on the vstack.
@@ -586,8 +608,28 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			// make sure this doesn't go out silently
-			p.addErr(errNoMatch)
+			if p.failureTracking {
+				// If parsing fails, but no errors have been recorded, the expected values
+				// for the farthest parser position are returned as error.
+				var expected []string
+				eof := ""
+				if _, ok := p.maxFailExpected["!."]; ok {
+					delete(p.maxFailExpected, "!.")
+					if len(p.maxFailExpected) > 0 {
+						eof = " or EOF"
+					} else {
+						eof = "EOF"
+					}
+				}
+				for k := range p.maxFailExpected {
+					expected = append(expected, k)
+				}
+				sort.Strings(expected)
+				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
+			} else {
+				// make sure this doesn't go out silently
+				p.addErr(errNoMatch)
+			}
 		}
 		return nil, p.errs.err()
 	}
@@ -733,8 +775,10 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	if p.pt.rn != utf8.RuneError {
 		start := p.pt
 		p.read()
+		p.failAt(true, start.position, ".")
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, p.pt.position, ".")
 	return nil, false
 }
 
@@ -744,11 +788,12 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	}
 
 	cur := p.pt.rn
+	start := p.pt
 	// can't match EOF
 	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
-	start := p.pt
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}
@@ -757,9 +802,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, rn := range chr.chars {
 		if rn == cur {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -768,9 +815,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for i := 0; i < len(chr.ranges); i += 2 {
 		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -779,17 +828,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, cl := range chr.classes {
 		if unicode.Is(cl, cur) {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
 
 	if chr.inverted {
 		p.read()
+		p.failAt(true, start.position, chr.val)
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, start.position, chr.val)
 	return nil, false
 }
 
@@ -829,6 +882,11 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -836,12 +894,33 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
+			p.failAt(false, start.position, val)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
+	p.failAt(true, start.position, val)
 	return p.sliceFrom(start), true
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if p.failureTracking && fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = make(map[string]struct{})
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected[want] = struct{}{}
+	}
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
@@ -863,7 +942,9 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 
 	pt := p.pt
 	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
 	p.restore(pt)
 	return nil, !ok

--- a/test/issue_12/issue_12.go
+++ b/test/issue_12/issue_12.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -249,6 +250,19 @@ func Recover(b bool) Option {
 	}
 }
 
+// FailureTracking creates an Option to set failureTracking flag to b.
+// When set to true, this causes the parser to track the farthest failures
+// and report them, if the parsing of the input fails.
+//
+// The default is false.
+func FailureTracking(b bool) Option {
+	return func(p *parser) Option {
+		old := p.failureTracking
+		p.failureTracking = b
+		return FailureTracking(old)
+	}
+}
+
 // ParseFile parses the file identified by filename.
 func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 	f, err := os.Open(filename)
@@ -442,11 +456,13 @@ func (p *parserError) Error() string {
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
 	p := &parser{
-		filename: filename,
-		errs:     new(errList),
-		data:     b,
-		pt:       savepoint{position: position{line: 1}},
-		recover:  true,
+		filename:        filename,
+		errs:            new(errList),
+		data:            b,
+		pt:              savepoint{position: position{line: 1}},
+		recover:         true,
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make(map[string]struct{}),
 	}
 	p.setOptions(opts)
 	return p
@@ -491,6 +507,12 @@ type parser struct {
 
 	// stats
 	exprCnt int
+
+	// parse fail
+	failureTracking       bool
+	maxFailPos            position
+	maxFailExpected       map[string]struct{}
+	maxFailInvertExpected bool
 }
 
 // push a variable set on the vstack.
@@ -673,8 +695,28 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			// make sure this doesn't go out silently
-			p.addErr(errNoMatch)
+			if p.failureTracking {
+				// If parsing fails, but no errors have been recorded, the expected values
+				// for the farthest parser position are returned as error.
+				var expected []string
+				eof := ""
+				if _, ok := p.maxFailExpected["!."]; ok {
+					delete(p.maxFailExpected, "!.")
+					if len(p.maxFailExpected) > 0 {
+						eof = " or EOF"
+					} else {
+						eof = "EOF"
+					}
+				}
+				for k := range p.maxFailExpected {
+					expected = append(expected, k)
+				}
+				sort.Strings(expected)
+				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
+			} else {
+				// make sure this doesn't go out silently
+				p.addErr(errNoMatch)
+			}
 		}
 		return nil, p.errs.err()
 	}
@@ -820,8 +862,10 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	if p.pt.rn != utf8.RuneError {
 		start := p.pt
 		p.read()
+		p.failAt(true, start.position, ".")
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, p.pt.position, ".")
 	return nil, false
 }
 
@@ -831,11 +875,12 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	}
 
 	cur := p.pt.rn
+	start := p.pt
 	// can't match EOF
 	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
-	start := p.pt
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}
@@ -844,9 +889,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, rn := range chr.chars {
 		if rn == cur {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -855,9 +902,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for i := 0; i < len(chr.ranges); i += 2 {
 		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -866,17 +915,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, cl := range chr.classes {
 		if unicode.Is(cl, cur) {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
 
 	if chr.inverted {
 		p.read()
+		p.failAt(true, start.position, chr.val)
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, start.position, chr.val)
 	return nil, false
 }
 
@@ -916,6 +969,11 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -923,12 +981,33 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
+			p.failAt(false, start.position, val)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
+	p.failAt(true, start.position, val)
 	return p.sliceFrom(start), true
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if p.failureTracking && fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = make(map[string]struct{})
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected[want] = struct{}{}
+	}
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
@@ -950,7 +1029,9 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 
 	pt := p.pt
 	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
 	p.restore(pt)
 	return nil, !ok

--- a/test/issue_12/issue_12.go
+++ b/test/issue_12/issue_12.go
@@ -201,9 +201,6 @@ var (
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
-
-	// errNoMatch is returned if no match could be found.
-	errNoMatch = errors.New("no match found")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -247,19 +244,6 @@ func Recover(b bool) Option {
 		old := p.recover
 		p.recover = b
 		return Recover(old)
-	}
-}
-
-// FailureTracking creates an Option to set failureTracking flag to b.
-// When set to true, this causes the parser to track the farthest failures
-// and report them, if the parsing of the input fails.
-//
-// The default is false.
-func FailureTracking(b bool) Option {
-	return func(p *parser) Option {
-		old := p.failureTracking
-		p.failureTracking = b
-		return FailureTracking(old)
 	}
 }
 
@@ -509,7 +493,6 @@ type parser struct {
 	exprCnt int
 
 	// parse fail
-	failureTracking       bool
 	maxFailPos            position
 	maxFailExpected       map[string]struct{}
 	maxFailInvertExpected bool
@@ -695,28 +678,23 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			if p.failureTracking {
-				// If parsing fails, but no errors have been recorded, the expected values
-				// for the farthest parser position are returned as error.
-				var expected []string
-				eof := ""
-				if _, ok := p.maxFailExpected["!."]; ok {
-					delete(p.maxFailExpected, "!.")
-					if len(p.maxFailExpected) > 0 {
-						eof = " or EOF"
-					} else {
-						eof = "EOF"
-					}
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			var expected []string
+			eof := ""
+			if _, ok := p.maxFailExpected["!."]; ok {
+				delete(p.maxFailExpected, "!.")
+				if len(p.maxFailExpected) > 0 {
+					eof = " or EOF"
+				} else {
+					eof = "EOF"
 				}
-				for k := range p.maxFailExpected {
-					expected = append(expected, k)
-				}
-				sort.Strings(expected)
-				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
-			} else {
-				// make sure this doesn't go out silently
-				p.addErr(errNoMatch)
 			}
+			for k := range p.maxFailExpected {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
 		}
 		return nil, p.errs.err()
 	}
@@ -993,7 +971,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 
 func (p *parser) failAt(fail bool, pos position, want string) {
 	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
-	if p.failureTracking && fail == p.maxFailInvertExpected {
+	if fail == p.maxFailInvertExpected {
 		if pos.offset < p.maxFailPos.offset {
 			return
 		}

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -1,0 +1,1070 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+func main() {
+	fmt.Println("without FailureTracking:")
+	_, err := Parse("", []byte(`123455`))
+	fmt.Println(err)
+	_, err = Parse("", []byte(`
+
+    1
+
+    2
+
+    3
+
+    `))
+	fmt.Println(err)
+	_, err = Parse("", []byte(`
+
+    1
+
+    2
+
+    x
+    `))
+	fmt.Println(err)
+	fmt.Println("\nwith FailureTracking:")
+	_, err = Parse("", []byte(`123455`), FailureTracking(true))
+	fmt.Println(err)
+	_, err = Parse("", []byte(`
+
+    1
+
+    2
+
+    3
+
+    `), FailureTracking(true))
+	fmt.Println(err)
+	_, err = Parse("", []byte(`
+
+    1
+
+    2
+
+    x
+    `), FailureTracking(true))
+	fmt.Println(err)
+}
+
+var g = &grammar{
+	rules: []*rule{
+		{
+			name: "Program",
+			pos:  position{line: 54, col: 1, offset: 660},
+			expr: &seqExpr{
+				pos: position{line: 54, col: 12, offset: 671},
+				exprs: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 54, col: 12, offset: 671},
+						name: "_",
+					},
+					&zeroOrMoreExpr{
+						pos: position{line: 54, col: 14, offset: 673},
+						expr: &seqExpr{
+							pos: position{line: 54, col: 15, offset: 674},
+							exprs: []interface{}{
+								&ruleRefExpr{
+									pos:  position{line: 54, col: 15, offset: 674},
+									name: "X",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 54, col: 17, offset: 676},
+									name: "_",
+								},
+							},
+						},
+					},
+					&ruleRefExpr{
+						pos:  position{line: 54, col: 21, offset: 680},
+						name: "_",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 54, col: 24, offset: 683},
+						name: "EOF",
+					},
+				},
+			},
+		},
+		{
+			name: "X",
+			pos:  position{line: 56, col: 1, offset: 688},
+			expr: &charClassMatcher{
+				pos:        position{line: 56, col: 6, offset: 693},
+				val:        "[0-9]",
+				ranges:     []rune{'0', '9'},
+				ignoreCase: false,
+				inverted:   false,
+			},
+		},
+		{
+			name:        "_",
+			displayName: "\"whitespace\"",
+			pos:         position{line: 58, col: 1, offset: 700},
+			expr: &zeroOrMoreExpr{
+				pos: position{line: 58, col: 19, offset: 718},
+				expr: &charClassMatcher{
+					pos:        position{line: 58, col: 21, offset: 720},
+					val:        "[ \\t\\r\\n]",
+					chars:      []rune{' ', '\t', '\r', '\n'},
+					ignoreCase: false,
+					inverted:   false,
+				},
+			},
+		},
+		{
+			name: "EOF",
+			pos:  position{line: 60, col: 1, offset: 734},
+			expr: &notExpr{
+				pos: position{line: 60, col: 8, offset: 741},
+				expr: &anyMatcher{
+					line: 60, col: 9, offset: 742,
+				},
+			},
+		},
+	},
+}
+
+var (
+	// errNoRule is returned when the grammar to parse has no rule.
+	errNoRule = errors.New("grammar has no rule")
+
+	// errInvalidEncoding is returned when the source is not properly
+	// utf8-encoded.
+	errInvalidEncoding = errors.New("invalid encoding")
+
+	// errNoMatch is returned if no match could be found.
+	errNoMatch = errors.New("no match found")
+)
+
+// Option is a function that can set an option on the parser. It returns
+// the previous setting as an Option.
+type Option func(*parser) Option
+
+// Debug creates an Option to set the debug flag to b. When set to true,
+// debugging information is printed to stdout while parsing.
+//
+// The default is false.
+func Debug(b bool) Option {
+	return func(p *parser) Option {
+		old := p.debug
+		p.debug = b
+		return Debug(old)
+	}
+}
+
+// Memoize creates an Option to set the memoize flag to b. When set to true,
+// the parser will cache all results so each expression is evaluated only
+// once. This guarantees linear parsing time even for pathological cases,
+// at the expense of more memory and slower times for typical cases.
+//
+// The default is false.
+func Memoize(b bool) Option {
+	return func(p *parser) Option {
+		old := p.memoize
+		p.memoize = b
+		return Memoize(old)
+	}
+}
+
+// Recover creates an Option to set the recover flag to b. When set to
+// true, this causes the parser to recover from panics and convert it
+// to an error. Setting it to false can be useful while debugging to
+// access the full stack trace.
+//
+// The default is true.
+func Recover(b bool) Option {
+	return func(p *parser) Option {
+		old := p.recover
+		p.recover = b
+		return Recover(old)
+	}
+}
+
+// FailureTracking creates an Option to set failureTracking flag to b.
+// When set to true, this causes the parser to track the farthest failures
+// and report them, if the parsing of the input fails.
+//
+// The default is false.
+func FailureTracking(b bool) Option {
+	return func(p *parser) Option {
+		old := p.failureTracking
+		p.failureTracking = b
+		return FailureTracking(old)
+	}
+}
+
+// ParseFile parses the file identified by filename.
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = f.Close()
+	}()
+	return ParseReader(filename, f, opts...)
+}
+
+// ParseReader parses the data from r using filename as information in the
+// error messages.
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return Parse(filename, b, opts...)
+}
+
+// Parse parses the data from b using filename as information in the
+// error messages.
+func Parse(filename string, b []byte, opts ...Option) (interface{}, error) {
+	return newParser(filename, b, opts...).parse(g)
+}
+
+// position records a position in the text.
+type position struct {
+	line, col, offset int
+}
+
+func (p position) String() string {
+	return fmt.Sprintf("%d:%d [%d]", p.line, p.col, p.offset)
+}
+
+// savepoint stores all state required to go back to this point in the
+// parser.
+type savepoint struct {
+	position
+	rn rune
+	w  int
+}
+
+type current struct {
+	pos  position // start position of the match
+	text []byte   // raw text of the match
+}
+
+// the AST types...
+
+type grammar struct {
+	pos   position
+	rules []*rule
+}
+
+type rule struct {
+	pos         position
+	name        string
+	displayName string
+	expr        interface{}
+}
+
+type choiceExpr struct {
+	pos          position
+	alternatives []interface{}
+}
+
+type actionExpr struct {
+	pos  position
+	expr interface{}
+	run  func(*parser) (interface{}, error)
+}
+
+type seqExpr struct {
+	pos   position
+	exprs []interface{}
+}
+
+type labeledExpr struct {
+	pos   position
+	label string
+	expr  interface{}
+}
+
+type expr struct {
+	pos  position
+	expr interface{}
+}
+
+type andExpr expr
+type notExpr expr
+type zeroOrOneExpr expr
+type zeroOrMoreExpr expr
+type oneOrMoreExpr expr
+
+type ruleRefExpr struct {
+	pos  position
+	name string
+}
+
+type andCodeExpr struct {
+	pos position
+	run func(*parser) (bool, error)
+}
+
+type notCodeExpr struct {
+	pos position
+	run func(*parser) (bool, error)
+}
+
+type litMatcher struct {
+	pos        position
+	val        string
+	ignoreCase bool
+}
+
+type charClassMatcher struct {
+	pos        position
+	val        string
+	chars      []rune
+	ranges     []rune
+	classes    []*unicode.RangeTable
+	ignoreCase bool
+	inverted   bool
+}
+
+type anyMatcher position
+
+// errList cumulates the errors found by the parser.
+type errList []error
+
+func (e *errList) add(err error) {
+	*e = append(*e, err)
+}
+
+func (e errList) err() error {
+	if len(e) == 0 {
+		return nil
+	}
+	e.dedupe()
+	return e
+}
+
+func (e *errList) dedupe() {
+	var cleaned []error
+	set := make(map[string]bool)
+	for _, err := range *e {
+		if msg := err.Error(); !set[msg] {
+			set[msg] = true
+			cleaned = append(cleaned, err)
+		}
+	}
+	*e = cleaned
+}
+
+func (e errList) Error() string {
+	switch len(e) {
+	case 0:
+		return ""
+	case 1:
+		return e[0].Error()
+	default:
+		var buf bytes.Buffer
+
+		for i, err := range e {
+			if i > 0 {
+				buf.WriteRune('\n')
+			}
+			buf.WriteString(err.Error())
+		}
+		return buf.String()
+	}
+}
+
+// parserError wraps an error with a prefix indicating the rule in which
+// the error occurred. The original error is stored in the Inner field.
+type parserError struct {
+	Inner  error
+	pos    position
+	prefix string
+}
+
+// Error returns the error message.
+func (p *parserError) Error() string {
+	return p.prefix + ": " + p.Inner.Error()
+}
+
+// newParser creates a parser with the specified input source and options.
+func newParser(filename string, b []byte, opts ...Option) *parser {
+	p := &parser{
+		filename:        filename,
+		errs:            new(errList),
+		data:            b,
+		pt:              savepoint{position: position{line: 1}},
+		recover:         true,
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make(map[string]struct{}),
+	}
+	p.setOptions(opts)
+	return p
+}
+
+// setOptions applies the options to the parser.
+func (p *parser) setOptions(opts []Option) {
+	for _, opt := range opts {
+		opt(p)
+	}
+}
+
+type resultTuple struct {
+	v   interface{}
+	b   bool
+	end savepoint
+}
+
+type parser struct {
+	filename string
+	pt       savepoint
+	cur      current
+
+	data []byte
+	errs *errList
+
+	depth   int
+	recover bool
+	debug   bool
+
+	memoize bool
+	// memoization table for the packrat algorithm:
+	// map[offset in source] map[expression or rule] {value, match}
+	memo map[int]map[interface{}]resultTuple
+
+	// rules table, maps the rule identifier to the rule node
+	rules map[string]*rule
+	// variables stack, map of label to value
+	vstack []map[string]interface{}
+	// rule stack, allows identification of the current rule in errors
+	rstack []*rule
+
+	// stats
+	exprCnt int
+
+	// parse fail
+	failureTracking       bool
+	maxFailPos            position
+	maxFailExpected       map[string]struct{}
+	maxFailInvertExpected bool
+}
+
+// push a variable set on the vstack.
+func (p *parser) pushV() {
+	if cap(p.vstack) == len(p.vstack) {
+		// create new empty slot in the stack
+		p.vstack = append(p.vstack, nil)
+	} else {
+		// slice to 1 more
+		p.vstack = p.vstack[:len(p.vstack)+1]
+	}
+
+	// get the last args set
+	m := p.vstack[len(p.vstack)-1]
+	if m != nil && len(m) == 0 {
+		// empty map, all good
+		return
+	}
+
+	m = make(map[string]interface{})
+	p.vstack[len(p.vstack)-1] = m
+}
+
+// pop a variable set from the vstack.
+func (p *parser) popV() {
+	// if the map is not empty, clear it
+	m := p.vstack[len(p.vstack)-1]
+	if len(m) > 0 {
+		// GC that map
+		p.vstack[len(p.vstack)-1] = nil
+	}
+	p.vstack = p.vstack[:len(p.vstack)-1]
+}
+
+func (p *parser) print(prefix, s string) string {
+	if !p.debug {
+		return s
+	}
+
+	fmt.Printf("%s %d:%d:%d: %s [%#U]\n",
+		prefix, p.pt.line, p.pt.col, p.pt.offset, s, p.pt.rn)
+	return s
+}
+
+func (p *parser) in(s string) string {
+	p.depth++
+	return p.print(strings.Repeat(" ", p.depth)+">", s)
+}
+
+func (p *parser) out(s string) string {
+	p.depth--
+	return p.print(strings.Repeat(" ", p.depth)+"<", s)
+}
+
+func (p *parser) addErr(err error) {
+	p.addErrAt(err, p.pt.position)
+}
+
+func (p *parser) addErrAt(err error, pos position) {
+	var buf bytes.Buffer
+	if p.filename != "" {
+		buf.WriteString(p.filename)
+	}
+	if buf.Len() > 0 {
+		buf.WriteString(":")
+	}
+	buf.WriteString(fmt.Sprintf("%d:%d (%d)", pos.line, pos.col, pos.offset))
+	if len(p.rstack) > 0 {
+		if buf.Len() > 0 {
+			buf.WriteString(": ")
+		}
+		rule := p.rstack[len(p.rstack)-1]
+		if rule.displayName != "" {
+			buf.WriteString("rule " + rule.displayName)
+		} else {
+			buf.WriteString("rule " + rule.name)
+		}
+	}
+	pe := &parserError{Inner: err, pos: pos, prefix: buf.String()}
+	p.errs.add(pe)
+}
+
+// read advances the parser to the next rune.
+func (p *parser) read() {
+	p.pt.offset += p.pt.w
+	rn, n := utf8.DecodeRune(p.data[p.pt.offset:])
+	p.pt.rn = rn
+	p.pt.w = n
+	p.pt.col++
+	if rn == '\n' {
+		p.pt.line++
+		p.pt.col = 0
+	}
+
+	if rn == utf8.RuneError {
+		if n == 1 {
+			p.addErr(errInvalidEncoding)
+		}
+	}
+}
+
+// restore parser position to the savepoint pt.
+func (p *parser) restore(pt savepoint) {
+	if p.debug {
+		defer p.out(p.in("restore"))
+	}
+	if pt.offset == p.pt.offset {
+		return
+	}
+	p.pt = pt
+}
+
+// get the slice of bytes from the savepoint start to the current position.
+func (p *parser) sliceFrom(start savepoint) []byte {
+	return p.data[start.position.offset:p.pt.position.offset]
+}
+
+func (p *parser) getMemoized(node interface{}) (resultTuple, bool) {
+	if len(p.memo) == 0 {
+		return resultTuple{}, false
+	}
+	m := p.memo[p.pt.offset]
+	if len(m) == 0 {
+		return resultTuple{}, false
+	}
+	res, ok := m[node]
+	return res, ok
+}
+
+func (p *parser) setMemoized(pt savepoint, node interface{}, tuple resultTuple) {
+	if p.memo == nil {
+		p.memo = make(map[int]map[interface{}]resultTuple)
+	}
+	m := p.memo[pt.offset]
+	if m == nil {
+		m = make(map[interface{}]resultTuple)
+		p.memo[pt.offset] = m
+	}
+	m[node] = tuple
+}
+
+func (p *parser) buildRulesTable(g *grammar) {
+	p.rules = make(map[string]*rule, len(g.rules))
+	for _, r := range g.rules {
+		p.rules[r.name] = r
+	}
+}
+
+func (p *parser) parse(g *grammar) (val interface{}, err error) {
+	if len(g.rules) == 0 {
+		p.addErr(errNoRule)
+		return nil, p.errs.err()
+	}
+
+	// TODO : not super critical but this could be generated
+	p.buildRulesTable(g)
+
+	if p.recover {
+		// panic can be used in action code to stop parsing immediately
+		// and return the panic as an error.
+		defer func() {
+			if e := recover(); e != nil {
+				if p.debug {
+					defer p.out(p.in("panic handler"))
+				}
+				val = nil
+				switch e := e.(type) {
+				case error:
+					p.addErr(e)
+				default:
+					p.addErr(fmt.Errorf("%v", e))
+				}
+				err = p.errs.err()
+			}
+		}()
+	}
+
+	// start rule is rule [0]
+	p.read() // advance to first rune
+	val, ok := p.parseRule(g.rules[0])
+	if !ok {
+		if len(*p.errs) == 0 {
+			if p.failureTracking {
+				// If parsing fails, but no errors have been recorded, the expected values
+				// for the farthest parser position are returned as error.
+				var expected []string
+				eof := ""
+				if _, ok := p.maxFailExpected["!."]; ok {
+					delete(p.maxFailExpected, "!.")
+					if len(p.maxFailExpected) > 0 {
+						eof = " or EOF"
+					} else {
+						eof = "EOF"
+					}
+				}
+				for k := range p.maxFailExpected {
+					expected = append(expected, k)
+				}
+				sort.Strings(expected)
+				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
+			} else {
+				// make sure this doesn't go out silently
+				p.addErr(errNoMatch)
+			}
+		}
+		return nil, p.errs.err()
+	}
+	return val, p.errs.err()
+}
+
+func (p *parser) parseRule(rule *rule) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseRule " + rule.name))
+	}
+
+	if p.memoize {
+		res, ok := p.getMemoized(rule)
+		if ok {
+			p.restore(res.end)
+			return res.v, res.b
+		}
+	}
+
+	start := p.pt
+	p.rstack = append(p.rstack, rule)
+	p.pushV()
+	val, ok := p.parseExpr(rule.expr)
+	p.popV()
+	p.rstack = p.rstack[:len(p.rstack)-1]
+	if ok && p.debug {
+		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
+	}
+
+	if p.memoize {
+		p.setMemoized(start, rule, resultTuple{val, ok, p.pt})
+	}
+	return val, ok
+}
+
+func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
+	var pt savepoint
+
+	if p.memoize {
+		res, ok := p.getMemoized(expr)
+		if ok {
+			p.restore(res.end)
+			return res.v, res.b
+		}
+		pt = p.pt
+	}
+
+	p.exprCnt++
+	var val interface{}
+	var ok bool
+	switch expr := expr.(type) {
+	case *actionExpr:
+		val, ok = p.parseActionExpr(expr)
+	case *andCodeExpr:
+		val, ok = p.parseAndCodeExpr(expr)
+	case *andExpr:
+		val, ok = p.parseAndExpr(expr)
+	case *anyMatcher:
+		val, ok = p.parseAnyMatcher(expr)
+	case *charClassMatcher:
+		val, ok = p.parseCharClassMatcher(expr)
+	case *choiceExpr:
+		val, ok = p.parseChoiceExpr(expr)
+	case *labeledExpr:
+		val, ok = p.parseLabeledExpr(expr)
+	case *litMatcher:
+		val, ok = p.parseLitMatcher(expr)
+	case *notCodeExpr:
+		val, ok = p.parseNotCodeExpr(expr)
+	case *notExpr:
+		val, ok = p.parseNotExpr(expr)
+	case *oneOrMoreExpr:
+		val, ok = p.parseOneOrMoreExpr(expr)
+	case *ruleRefExpr:
+		val, ok = p.parseRuleRefExpr(expr)
+	case *seqExpr:
+		val, ok = p.parseSeqExpr(expr)
+	case *zeroOrMoreExpr:
+		val, ok = p.parseZeroOrMoreExpr(expr)
+	case *zeroOrOneExpr:
+		val, ok = p.parseZeroOrOneExpr(expr)
+	default:
+		panic(fmt.Sprintf("unknown expression type %T", expr))
+	}
+	if p.memoize {
+		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
+	}
+	return val, ok
+}
+
+func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseActionExpr"))
+	}
+
+	start := p.pt
+	val, ok := p.parseExpr(act.expr)
+	if ok {
+		p.cur.pos = start.position
+		p.cur.text = p.sliceFrom(start)
+		actVal, err := act.run(p)
+		if err != nil {
+			p.addErrAt(err, start.position)
+		}
+		val = actVal
+	}
+	if ok && p.debug {
+		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
+	}
+	return val, ok
+}
+
+func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseAndCodeExpr"))
+	}
+
+	ok, err := and.run(p)
+	if err != nil {
+		p.addErr(err)
+	}
+	return nil, ok
+}
+
+func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseAndExpr"))
+	}
+
+	pt := p.pt
+	p.pushV()
+	_, ok := p.parseExpr(and.expr)
+	p.popV()
+	p.restore(pt)
+	return nil, ok
+}
+
+func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseAnyMatcher"))
+	}
+
+	if p.pt.rn != utf8.RuneError {
+		start := p.pt
+		p.read()
+		p.failAt(true, start.position, ".")
+		return p.sliceFrom(start), true
+	}
+	p.failAt(false, p.pt.position, ".")
+	return nil, false
+}
+
+func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseCharClassMatcher"))
+	}
+
+	cur := p.pt.rn
+	start := p.pt
+	// can't match EOF
+	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
+		return nil, false
+	}
+	if chr.ignoreCase {
+		cur = unicode.ToLower(cur)
+	}
+
+	// try to match in the list of available chars
+	for _, rn := range chr.chars {
+		if rn == cur {
+			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
+				return nil, false
+			}
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+	}
+
+	// try to match in the list of ranges
+	for i := 0; i < len(chr.ranges); i += 2 {
+		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
+			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
+				return nil, false
+			}
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+	}
+
+	// try to match in the list of Unicode classes
+	for _, cl := range chr.classes {
+		if unicode.Is(cl, cur) {
+			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
+				return nil, false
+			}
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+	}
+
+	if chr.inverted {
+		p.read()
+		p.failAt(true, start.position, chr.val)
+		return p.sliceFrom(start), true
+	}
+	p.failAt(false, start.position, chr.val)
+	return nil, false
+}
+
+func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseChoiceExpr"))
+	}
+
+	for _, alt := range ch.alternatives {
+		p.pushV()
+		val, ok := p.parseExpr(alt)
+		p.popV()
+		if ok {
+			return val, ok
+		}
+	}
+	return nil, false
+}
+
+func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseLabeledExpr"))
+	}
+
+	p.pushV()
+	val, ok := p.parseExpr(lab.expr)
+	p.popV()
+	if ok && lab.label != "" {
+		m := p.vstack[len(p.vstack)-1]
+		m[lab.label] = val
+	}
+	return val, ok
+}
+
+func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseLitMatcher"))
+	}
+
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
+	start := p.pt
+	for _, want := range lit.val {
+		cur := p.pt.rn
+		if lit.ignoreCase {
+			cur = unicode.ToLower(cur)
+		}
+		if cur != want {
+			p.failAt(false, start.position, val)
+			p.restore(start)
+			return nil, false
+		}
+		p.read()
+	}
+	p.failAt(true, start.position, val)
+	return p.sliceFrom(start), true
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if p.failureTracking && fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = make(map[string]struct{})
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected[want] = struct{}{}
+	}
+}
+
+func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseNotCodeExpr"))
+	}
+
+	ok, err := not.run(p)
+	if err != nil {
+		p.addErr(err)
+	}
+	return nil, !ok
+}
+
+func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseNotExpr"))
+	}
+
+	pt := p.pt
+	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
+	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
+	p.popV()
+	p.restore(pt)
+	return nil, !ok
+}
+
+func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseOneOrMoreExpr"))
+	}
+
+	var vals []interface{}
+
+	for {
+		p.pushV()
+		val, ok := p.parseExpr(expr.expr)
+		p.popV()
+		if !ok {
+			if len(vals) == 0 {
+				// did not match once, no match
+				return nil, false
+			}
+			return vals, true
+		}
+		vals = append(vals, val)
+	}
+}
+
+func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseRuleRefExpr " + ref.name))
+	}
+
+	if ref.name == "" {
+		panic(fmt.Sprintf("%s: invalid rule: missing name", ref.pos))
+	}
+
+	rule := p.rules[ref.name]
+	if rule == nil {
+		p.addErr(fmt.Errorf("undefined rule: %s", ref.name))
+		return nil, false
+	}
+	return p.parseRule(rule)
+}
+
+func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseSeqExpr"))
+	}
+
+	var vals []interface{}
+
+	pt := p.pt
+	for _, expr := range seq.exprs {
+		val, ok := p.parseExpr(expr)
+		if !ok {
+			p.restore(pt)
+			return nil, false
+		}
+		vals = append(vals, val)
+	}
+	return vals, true
+}
+
+func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseZeroOrMoreExpr"))
+	}
+
+	var vals []interface{}
+
+	for {
+		p.pushV()
+		val, ok := p.parseExpr(expr.expr)
+		p.popV()
+		if !ok {
+			return vals, true
+		}
+		vals = append(vals, val)
+	}
+}
+
+func (p *parser) parseZeroOrOneExpr(expr *zeroOrOneExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseZeroOrOneExpr"))
+	}
+
+	p.pushV()
+	val, _ := p.parseExpr(expr.expr)
+	p.popV()
+	// whether it matched or not, consider it a match
+	return val, true
+}

--- a/test/issue_18/issue_18.peg
+++ b/test/issue_18/issue_18.peg
@@ -4,7 +4,7 @@ package main
 import "fmt"
 
 func main() {
-    fmt.Println("without FailureTracking:")
+    fmt.Println("with FailureTracking:")
     _, err := Parse("", []byte(`123455`))
     fmt.Println(err)
     _, err = Parse("", []byte(`
@@ -25,28 +25,6 @@ func main() {
 
     x
     `))
-    fmt.Println(err)
-    fmt.Println("\nwith FailureTracking:")
-    _, err = Parse("", []byte(`123455`), FailureTracking(true))
-    fmt.Println(err)
-    _, err = Parse("", []byte(`
-
-    1
-
-    2
-
-    3
-
-    `), FailureTracking(true))
-    fmt.Println(err)
-    _, err = Parse("", []byte(`
-
-    1
-
-    2
-
-    x
-    `), FailureTracking(true))
     fmt.Println(err)
 }
 }

--- a/test/issue_18/issue_18.peg
+++ b/test/issue_18/issue_18.peg
@@ -1,0 +1,60 @@
+{
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("without FailureTracking:")
+    _, err := Parse("", []byte(`123455`))
+    fmt.Println(err)
+    _, err = Parse("", []byte(`
+
+    1
+
+    2
+
+    3
+
+    `))
+    fmt.Println(err)
+    _, err = Parse("", []byte(`
+
+    1
+
+    2
+
+    x
+    `))
+    fmt.Println(err)
+    fmt.Println("\nwith FailureTracking:")
+    _, err = Parse("", []byte(`123455`), FailureTracking(true))
+    fmt.Println(err)
+    _, err = Parse("", []byte(`
+
+    1
+
+    2
+
+    3
+
+    `), FailureTracking(true))
+    fmt.Println(err)
+    _, err = Parse("", []byte(`
+
+    1
+
+    2
+
+    x
+    `), FailureTracking(true))
+    fmt.Println(err)
+}
+}
+
+Program <- _ (X _)* _  EOF
+
+X <- [0-9]
+
+_ "whitespace" <- ( [ \t\r\n] )*
+
+EOF <- !.

--- a/test/issue_18/issue_18_test.go
+++ b/test/issue_18/issue_18_test.go
@@ -1,0 +1,65 @@
+package main
+
+import "testing"
+
+var cases = map[string]string{
+	`123455`: ``,
+	`
+
+    1
+
+    2
+
+    3
+
+    `: ``,
+	`
+
+    1
+
+    2
+
+    x
+    `: `2:0 (0): no match found`,
+}
+
+var casesFailureTracking = map[string]string{
+	`
+
+    1
+
+    2
+
+    x
+    `: `7:5 (20): no match found, expected: [ \t\r\n], [0-9] or EOF`,
+}
+
+func TestErrorReporting(t *testing.T) {
+	config := []struct {
+		failureTracking bool
+	}{
+		{
+			failureTracking: false,
+		},
+		{
+			failureTracking: true,
+		},
+	}
+	for _, conf := range config {
+		for tc, exp := range cases {
+			_, err := Parse("", []byte(tc), FailureTracking(conf.failureTracking))
+			var got string
+			if err != nil {
+				got = err.Error()
+			}
+			if conf.failureTracking {
+				if failTrackExp, ok := casesFailureTracking[tc]; ok {
+					exp = failTrackExp
+				}
+			}
+			if got != exp {
+				t.Errorf("%q: want %v, got %v", tc, exp, got)
+			}
+		}
+	}
+}

--- a/test/issue_18/issue_18_test.go
+++ b/test/issue_18/issue_18_test.go
@@ -20,46 +20,20 @@ var cases = map[string]string{
     2
 
     x
-    `: `2:0 (0): no match found`,
-}
-
-var casesFailureTracking = map[string]string{
-	`
-
-    1
-
-    2
-
-    x
     `: `7:5 (20): no match found, expected: [ \t\r\n], [0-9] or EOF`,
 }
 
 func TestErrorReporting(t *testing.T) {
-	config := []struct {
-		failureTracking bool
-	}{
-		{
-			failureTracking: false,
-		},
-		{
-			failureTracking: true,
-		},
-	}
-	for _, conf := range config {
-		for tc, exp := range cases {
-			_, err := Parse("", []byte(tc), FailureTracking(conf.failureTracking))
-			var got string
-			if err != nil {
-				got = err.Error()
-			}
-			if conf.failureTracking {
-				if failTrackExp, ok := casesFailureTracking[tc]; ok {
-					exp = failTrackExp
-				}
-			}
-			if got != exp {
-				t.Errorf("%q: want %v, got %v", tc, exp, got)
-			}
+	for tc, exp := range cases {
+		_, err := Parse("", []byte(tc))
+		var got string
+		if err != nil {
+			got = err.Error()
 		}
+
+		if got != exp {
+			t.Errorf("%q: want %v, got %v", tc, exp, got)
+		}
+
 	}
 }

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -249,6 +250,19 @@ func Recover(b bool) Option {
 	}
 }
 
+// FailureTracking creates an Option to set failureTracking flag to b.
+// When set to true, this causes the parser to track the farthest failures
+// and report them, if the parsing of the input fails.
+//
+// The default is false.
+func FailureTracking(b bool) Option {
+	return func(p *parser) Option {
+		old := p.failureTracking
+		p.failureTracking = b
+		return FailureTracking(old)
+	}
+}
+
 // ParseFile parses the file identified by filename.
 func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 	f, err := os.Open(filename)
@@ -442,11 +456,13 @@ func (p *parserError) Error() string {
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
 	p := &parser{
-		filename: filename,
-		errs:     new(errList),
-		data:     b,
-		pt:       savepoint{position: position{line: 1}},
-		recover:  true,
+		filename:        filename,
+		errs:            new(errList),
+		data:            b,
+		pt:              savepoint{position: position{line: 1}},
+		recover:         true,
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make(map[string]struct{}),
 	}
 	p.setOptions(opts)
 	return p
@@ -491,6 +507,12 @@ type parser struct {
 
 	// stats
 	exprCnt int
+
+	// parse fail
+	failureTracking       bool
+	maxFailPos            position
+	maxFailExpected       map[string]struct{}
+	maxFailInvertExpected bool
 }
 
 // push a variable set on the vstack.
@@ -673,8 +695,28 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			// make sure this doesn't go out silently
-			p.addErr(errNoMatch)
+			if p.failureTracking {
+				// If parsing fails, but no errors have been recorded, the expected values
+				// for the farthest parser position are returned as error.
+				var expected []string
+				eof := ""
+				if _, ok := p.maxFailExpected["!."]; ok {
+					delete(p.maxFailExpected, "!.")
+					if len(p.maxFailExpected) > 0 {
+						eof = " or EOF"
+					} else {
+						eof = "EOF"
+					}
+				}
+				for k := range p.maxFailExpected {
+					expected = append(expected, k)
+				}
+				sort.Strings(expected)
+				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
+			} else {
+				// make sure this doesn't go out silently
+				p.addErr(errNoMatch)
+			}
 		}
 		return nil, p.errs.err()
 	}
@@ -820,8 +862,10 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	if p.pt.rn != utf8.RuneError {
 		start := p.pt
 		p.read()
+		p.failAt(true, start.position, ".")
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, p.pt.position, ".")
 	return nil, false
 }
 
@@ -831,11 +875,12 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	}
 
 	cur := p.pt.rn
+	start := p.pt
 	// can't match EOF
 	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
-	start := p.pt
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}
@@ -844,9 +889,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, rn := range chr.chars {
 		if rn == cur {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -855,9 +902,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for i := 0; i < len(chr.ranges); i += 2 {
 		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -866,17 +915,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, cl := range chr.classes {
 		if unicode.Is(cl, cur) {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
 
 	if chr.inverted {
 		p.read()
+		p.failAt(true, start.position, chr.val)
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, start.position, chr.val)
 	return nil, false
 }
 
@@ -916,6 +969,11 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -923,12 +981,33 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
+			p.failAt(false, start.position, val)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
+	p.failAt(true, start.position, val)
 	return p.sliceFrom(start), true
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if p.failureTracking && fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = make(map[string]struct{})
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected[want] = struct{}{}
+	}
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
@@ -950,7 +1029,9 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 
 	pt := p.pt
 	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
 	p.restore(pt)
 	return nil, !ok

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -201,9 +201,6 @@ var (
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
-
-	// errNoMatch is returned if no match could be found.
-	errNoMatch = errors.New("no match found")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -247,19 +244,6 @@ func Recover(b bool) Option {
 		old := p.recover
 		p.recover = b
 		return Recover(old)
-	}
-}
-
-// FailureTracking creates an Option to set failureTracking flag to b.
-// When set to true, this causes the parser to track the farthest failures
-// and report them, if the parsing of the input fails.
-//
-// The default is false.
-func FailureTracking(b bool) Option {
-	return func(p *parser) Option {
-		old := p.failureTracking
-		p.failureTracking = b
-		return FailureTracking(old)
 	}
 }
 
@@ -509,7 +493,6 @@ type parser struct {
 	exprCnt int
 
 	// parse fail
-	failureTracking       bool
 	maxFailPos            position
 	maxFailExpected       map[string]struct{}
 	maxFailInvertExpected bool
@@ -695,28 +678,23 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			if p.failureTracking {
-				// If parsing fails, but no errors have been recorded, the expected values
-				// for the farthest parser position are returned as error.
-				var expected []string
-				eof := ""
-				if _, ok := p.maxFailExpected["!."]; ok {
-					delete(p.maxFailExpected, "!.")
-					if len(p.maxFailExpected) > 0 {
-						eof = " or EOF"
-					} else {
-						eof = "EOF"
-					}
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			var expected []string
+			eof := ""
+			if _, ok := p.maxFailExpected["!."]; ok {
+				delete(p.maxFailExpected, "!.")
+				if len(p.maxFailExpected) > 0 {
+					eof = " or EOF"
+				} else {
+					eof = "EOF"
 				}
-				for k := range p.maxFailExpected {
-					expected = append(expected, k)
-				}
-				sort.Strings(expected)
-				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
-			} else {
-				// make sure this doesn't go out silently
-				p.addErr(errNoMatch)
 			}
+			for k := range p.maxFailExpected {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
 		}
 		return nil, p.errs.err()
 	}
@@ -993,7 +971,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 
 func (p *parser) failAt(fail bool, pos position, want string) {
 	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
-	if p.failureTracking && fail == p.maxFailInvertExpected {
+	if fail == p.maxFailInvertExpected {
 		if pos.offset < p.maxFailPos.offset {
 			return
 		}

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -297,6 +298,19 @@ func Recover(b bool) Option {
 	}
 }
 
+// FailureTracking creates an Option to set failureTracking flag to b.
+// When set to true, this causes the parser to track the farthest failures
+// and report them, if the parsing of the input fails.
+//
+// The default is false.
+func FailureTracking(b bool) Option {
+	return func(p *parser) Option {
+		old := p.failureTracking
+		p.failureTracking = b
+		return FailureTracking(old)
+	}
+}
+
 // ParseFile parses the file identified by filename.
 func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 	f, err := os.Open(filename)
@@ -490,11 +504,13 @@ func (p *parserError) Error() string {
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
 	p := &parser{
-		filename: filename,
-		errs:     new(errList),
-		data:     b,
-		pt:       savepoint{position: position{line: 1}},
-		recover:  true,
+		filename:        filename,
+		errs:            new(errList),
+		data:            b,
+		pt:              savepoint{position: position{line: 1}},
+		recover:         true,
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make(map[string]struct{}),
 	}
 	p.setOptions(opts)
 	return p
@@ -539,6 +555,12 @@ type parser struct {
 
 	// stats
 	exprCnt int
+
+	// parse fail
+	failureTracking       bool
+	maxFailPos            position
+	maxFailExpected       map[string]struct{}
+	maxFailInvertExpected bool
 }
 
 // push a variable set on the vstack.
@@ -721,8 +743,28 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			// make sure this doesn't go out silently
-			p.addErr(errNoMatch)
+			if p.failureTracking {
+				// If parsing fails, but no errors have been recorded, the expected values
+				// for the farthest parser position are returned as error.
+				var expected []string
+				eof := ""
+				if _, ok := p.maxFailExpected["!."]; ok {
+					delete(p.maxFailExpected, "!.")
+					if len(p.maxFailExpected) > 0 {
+						eof = " or EOF"
+					} else {
+						eof = "EOF"
+					}
+				}
+				for k := range p.maxFailExpected {
+					expected = append(expected, k)
+				}
+				sort.Strings(expected)
+				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
+			} else {
+				// make sure this doesn't go out silently
+				p.addErr(errNoMatch)
+			}
 		}
 		return nil, p.errs.err()
 	}
@@ -868,8 +910,10 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	if p.pt.rn != utf8.RuneError {
 		start := p.pt
 		p.read()
+		p.failAt(true, start.position, ".")
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, p.pt.position, ".")
 	return nil, false
 }
 
@@ -879,11 +923,12 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	}
 
 	cur := p.pt.rn
+	start := p.pt
 	// can't match EOF
 	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
-	start := p.pt
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}
@@ -892,9 +937,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, rn := range chr.chars {
 		if rn == cur {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -903,9 +950,11 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for i := 0; i < len(chr.ranges); i += 2 {
 		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
@@ -914,17 +963,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	for _, cl := range chr.classes {
 		if unicode.Is(cl, cur) {
 			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
 				return nil, false
 			}
 			p.read()
+			p.failAt(true, start.position, chr.val)
 			return p.sliceFrom(start), true
 		}
 	}
 
 	if chr.inverted {
 		p.read()
+		p.failAt(true, start.position, chr.val)
 		return p.sliceFrom(start), true
 	}
+	p.failAt(false, start.position, chr.val)
 	return nil, false
 }
 
@@ -964,6 +1017,11 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -971,12 +1029,33 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
+			p.failAt(false, start.position, val)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
+	p.failAt(true, start.position, val)
 	return p.sliceFrom(start), true
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if p.failureTracking && fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = make(map[string]struct{})
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected[want] = struct{}{}
+	}
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
@@ -998,7 +1077,9 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 
 	pt := p.pt
 	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
 	p.restore(pt)
 	return nil, !ok

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -249,9 +249,6 @@ var (
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
-
-	// errNoMatch is returned if no match could be found.
-	errNoMatch = errors.New("no match found")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -295,19 +292,6 @@ func Recover(b bool) Option {
 		old := p.recover
 		p.recover = b
 		return Recover(old)
-	}
-}
-
-// FailureTracking creates an Option to set failureTracking flag to b.
-// When set to true, this causes the parser to track the farthest failures
-// and report them, if the parsing of the input fails.
-//
-// The default is false.
-func FailureTracking(b bool) Option {
-	return func(p *parser) Option {
-		old := p.failureTracking
-		p.failureTracking = b
-		return FailureTracking(old)
 	}
 }
 
@@ -557,7 +541,6 @@ type parser struct {
 	exprCnt int
 
 	// parse fail
-	failureTracking       bool
 	maxFailPos            position
 	maxFailExpected       map[string]struct{}
 	maxFailInvertExpected bool
@@ -743,28 +726,23 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	val, ok := p.parseRule(g.rules[0])
 	if !ok {
 		if len(*p.errs) == 0 {
-			if p.failureTracking {
-				// If parsing fails, but no errors have been recorded, the expected values
-				// for the farthest parser position are returned as error.
-				var expected []string
-				eof := ""
-				if _, ok := p.maxFailExpected["!."]; ok {
-					delete(p.maxFailExpected, "!.")
-					if len(p.maxFailExpected) > 0 {
-						eof = " or EOF"
-					} else {
-						eof = "EOF"
-					}
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			var expected []string
+			eof := ""
+			if _, ok := p.maxFailExpected["!."]; ok {
+				delete(p.maxFailExpected, "!.")
+				if len(p.maxFailExpected) > 0 {
+					eof = " or EOF"
+				} else {
+					eof = "EOF"
 				}
-				for k := range p.maxFailExpected {
-					expected = append(expected, k)
-				}
-				sort.Strings(expected)
-				p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
-			} else {
-				// make sure this doesn't go out silently
-				p.addErr(errNoMatch)
 			}
+			for k := range p.maxFailExpected {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			p.addErrAt(errors.New("no match found, expected: "+strings.Join(expected, ", ")+eof), p.maxFailPos)
 		}
 		return nil, p.errs.err()
 	}
@@ -1041,7 +1019,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 
 func (p *parser) failAt(fail bool, pos position, want string) {
 	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
-	if p.failureTracking && fail == p.maxFailInvertExpected {
+	if fail == p.maxFailInvertExpected {
 		if pos.offset < p.maxFailPos.offset {
 			return
 		}


### PR DESCRIPTION
Add FailureTracking as flag to pigeon and to existing tests and examples.

Builds on #24 
Fixes #18