### PR TITLE
Added `-optimize-parser` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,11 @@ $(PIGEON_GRAMMAR):
 
 # surely there's a better way to define the examples and test targets
 
-$(EXAMPLES_DIR)/json/json.go: $(EXAMPLES_DIR)/json/json.peg $(BINDIR)/pigeon
+$(EXAMPLES_DIR)/json/json.go: $(EXAMPLES_DIR)/json/json.peg $(EXAMPLES_DIR)/json/optimized/json.go $(BINDIR)/pigeon
 	$(BINDIR)/pigeon $< > $@
+
+$(EXAMPLES_DIR)/json/optimized/json.go: $(EXAMPLES_DIR)/json/json.peg $(BINDIR)/pigeon
+	$(BINDIR)/pigeon -optimize-parser $< > $@
 
 $(EXAMPLES_DIR)/calculator/calculator.go: $(EXAMPLES_DIR)/calculator/calculator.peg $(BINDIR)/pigeon
 	$(BINDIR)/pigeon $< > $@
@@ -108,7 +111,7 @@ cmp:
 
 clean:
 	rm -f $(BUILDER_DIR)/generated_static_code.go $(BUILDER_DIR)/generated_static_code_range_table.go
-	rm -f $(BOOTSTRAPPIGEON_DIR)/bootstrap_pigeon.go $(ROOT)/pigeon.go $(TEST_GENERATED_SRC)
+	rm -f $(BOOTSTRAPPIGEON_DIR)/bootstrap_pigeon.go $(ROOT)/pigeon.go $(TEST_GENERATED_SRC) $(EXAMPLES_DIR)/json/optimized/json.go
 	rm -rf $(BINDIR)
 
 .PHONY: all clean lint cmp

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -31,6 +31,7 @@ var (
 // the previous setting as an Option.
 type Option func(*parser) Option
 
+// ==template== {{ if not .Optimize }}
 // Debug creates an Option to set the debug flag to b. When set to true,
 // debugging information is printed to stdout while parsing.
 //
@@ -56,6 +57,8 @@ func Memoize(b bool) Option {
 		return Memoize(old)
 	}
 }
+
+// {{ end }} ==template==
 
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
@@ -300,12 +303,14 @@ type parser struct {
 
 	depth   int
 	recover bool
-	debug   bool
+	// ==template== {{ if not .Optimize }}
+	debug bool
 
 	memoize bool
 	// memoization table for the packrat algorithm:
 	// map[offset in source] map[expression or rule] {value, match}
 	memo map[int]map[interface{}]resultTuple
+	// {{ end }} ==template==
 
 	// rules table, maps the rule identifier to the rule node
 	rules map[string]*rule
@@ -314,8 +319,10 @@ type parser struct {
 	// rule stack, allows identification of the current rule in errors
 	rstack []*rule
 
+	// ==template== {{ if not .Optimize }}
 	// stats
 	exprCnt int
+	// {{ end }} ==template==
 
 	// parse fail
 	maxFailPos            position
@@ -355,6 +362,7 @@ func (p *parser) popV() {
 	p.vstack = p.vstack[:len(p.vstack)-1]
 }
 
+// ==template== {{ if not .Optimize }}
 func (p *parser) print(prefix, s string) string {
 	if !p.debug {
 		return s
@@ -374,6 +382,8 @@ func (p *parser) out(s string) string {
 	p.depth--
 	return p.print(strings.Repeat(" ", p.depth)+"<", s)
 }
+
+// {{ end }} ==template==
 
 func (p *parser) addErr(err error) {
 	p.addErrAt(err, p.pt.position, []string{})
@@ -443,9 +453,11 @@ func (p *parser) read() {
 
 // restore parser position to the savepoint pt.
 func (p *parser) restore(pt savepoint) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("restore"))
 	}
+	// {{ end }} ==template==
 	if pt.offset == p.pt.offset {
 		return
 	}
@@ -457,6 +469,7 @@ func (p *parser) sliceFrom(start savepoint) []byte {
 	return p.data[start.position.offset:p.pt.position.offset]
 }
 
+// ==template== {{ if not .Optimize }}
 func (p *parser) getMemoized(node interface{}) (resultTuple, bool) {
 	if len(p.memo) == 0 {
 		return resultTuple{}, false
@@ -481,6 +494,8 @@ func (p *parser) setMemoized(pt savepoint, node interface{}, tuple resultTuple) 
 	m[node] = tuple
 }
 
+// {{ end }} ==template==
+
 func (p *parser) buildRulesTable(g *grammar) {
 	p.rules = make(map[string]*rule, len(g.rules))
 	for _, r := range g.rules {
@@ -502,9 +517,11 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		// and return the panic as an error.
 		defer func() {
 			if e := recover(); e != nil {
+				// ==template== {{ if not .Optimize }}
 				if p.debug {
 					defer p.out(p.in("panic handler"))
 				}
+				// {{ end }} ==template==
 				val = nil
 				switch e := e.(type) {
 				case error:
@@ -556,6 +573,7 @@ func listJoin(list []string, sep string, lastSep string) string {
 }
 
 func (p *parser) parseRule(rule *rule) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseRule " + rule.name))
 	}
@@ -569,11 +587,13 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	}
 
 	start := p.pt
+	// {{ end }} ==template==
 	p.rstack = append(p.rstack, rule)
 	p.pushV()
 	val, ok := p.parseExpr(rule.expr)
 	p.popV()
 	p.rstack = p.rstack[:len(p.rstack)-1]
+	// ==template== {{ if not .Optimize }}
 	if ok && p.debug {
 		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
 	}
@@ -581,10 +601,12 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	if p.memoize {
 		p.setMemoized(start, rule, resultTuple{val, ok, p.pt})
 	}
+	// {{ end }} ==template==
 	return val, ok
 }
 
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	var pt savepoint
 
 	if p.memoize {
@@ -597,6 +619,7 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	}
 
 	p.exprCnt++
+	// {{ end }} ==template==
 	var val interface{}
 	var ok bool
 	switch expr := expr.(type) {
@@ -633,17 +656,21 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	default:
 		panic(fmt.Sprintf("unknown expression type %T", expr))
 	}
+	// ==template== {{ if not .Optimize }}
 	if p.memoize {
 		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
 	}
+	// {{ end }} ==template==
 	return val, ok
 }
 
 func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseActionExpr"))
 	}
 
+	// {{ end }} ==template==
 	start := p.pt
 	val, ok := p.parseExpr(act.expr)
 	if ok {
@@ -655,17 +682,21 @@ func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
 		}
 		val = actVal
 	}
+	// ==template== {{ if not .Optimize }}
 	if ok && p.debug {
 		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
 	}
+	// {{ end }} ==template==
 	return val, ok
 }
 
 func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseAndCodeExpr"))
 	}
 
+	// {{ end }} ==template==
 	ok, err := and.run(p)
 	if err != nil {
 		p.addErr(err)
@@ -674,10 +705,12 @@ func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseAndExpr"))
 	}
 
+	// {{ end }} ==template==
 	pt := p.pt
 	p.pushV()
 	_, ok := p.parseExpr(and.expr)
@@ -687,10 +720,12 @@ func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
+	// {{ end }} ==template==
 	if p.pt.rn != utf8.RuneError {
 		start := p.pt
 		p.read()
@@ -702,10 +737,12 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))
 	}
 
+	// {{ end }} ==template==
 	cur := p.pt.rn
 	start := p.pt
 	// can't match EOF
@@ -766,10 +803,12 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
+	// {{ end }} ==template==
 	for _, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
@@ -782,10 +821,12 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseLabeledExpr"))
 	}
 
+	// {{ end }} ==template==
 	p.pushV()
 	val, ok := p.parseExpr(lab.expr)
 	p.popV()
@@ -797,10 +838,12 @@ func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
+	// {{ end }} ==template==
 	ignoreCase := ""
 	if lit.ignoreCase {
 		ignoreCase = "i"
@@ -824,10 +867,12 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseNotCodeExpr"))
 	}
 
+	// {{ end }} ==template==
 	ok, err := not.run(p)
 	if err != nil {
 		p.addErr(err)
@@ -836,10 +881,12 @@ func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseNotExpr"))
 	}
 
+	// {{ end }} ==template==
 	pt := p.pt
 	p.pushV()
 	p.maxFailInvertExpected = !p.maxFailInvertExpected
@@ -851,10 +898,12 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseOneOrMoreExpr"))
 	}
 
+	// {{ end }} ==template==
 	var vals []interface{}
 
 	for {
@@ -873,10 +922,12 @@ func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseRuleRefExpr " + ref.name))
 	}
 
+	// {{ end }} ==template==
 	if ref.name == "" {
 		panic(fmt.Sprintf("%s: invalid rule: missing name", ref.pos))
 	}
@@ -890,10 +941,12 @@ func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseSeqExpr"))
 	}
 
+	// {{ end }} ==template==
 	var vals []interface{}
 
 	pt := p.pt
@@ -909,10 +962,12 @@ func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseZeroOrMoreExpr"))
 	}
 
+	// {{ end }} ==template==
 	var vals []interface{}
 
 	for {
@@ -927,10 +982,12 @@ func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseZeroOrOneExpr(expr *zeroOrOneExpr) (interface{}, bool) {
+	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseZeroOrOneExpr"))
 	}
 
+	// {{ end }} ==template==
 	p.pushV()
 	val, _ := p.parseExpr(expr.expr)
 	p.popV()

--- a/doc.go
+++ b/doc.go
@@ -42,6 +42,10 @@ The following options can be specified:
 	-o=FILE : string, output file where the generated parser will be
 	written (default: stdout).
 
+	-optimize-parser : boolean, if set, the options Debug and Memoize are removed
+	from the resulting parser. This saves a few cpu cycles, when using the
+	generated parser (default: false).
+
 	-x : boolean, if set, do not build the parser, just parse the input grammar
 	(default: false).
 

--- a/examples/json/json_test.go
+++ b/examples/json/json_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	optimized "github.com/mna/pigeon/examples/json/optimized"
 )
 
 func TestCmpStdlib(t *testing.T) {
@@ -14,6 +16,12 @@ func TestCmpStdlib(t *testing.T) {
 		pgot, err := ParseFile(file)
 		if err != nil {
 			t.Errorf("%s: pigeon.ParseFile: %v", file, err)
+			continue
+		}
+
+		pogot, err := optimized.ParseFile(file)
+		if err != nil {
+			t.Errorf("%s: optimized.ParseFile: %v", file, err)
 			continue
 		}
 
@@ -30,6 +38,11 @@ func TestCmpStdlib(t *testing.T) {
 
 		if !reflect.DeepEqual(pgot, jgot) {
 			t.Errorf("%s: not equal", file)
+			continue
+		}
+
+		if !reflect.DeepEqual(pogot, jgot) {
+			t.Errorf("%s: optimized not equal", file)
 			continue
 		}
 	}
@@ -74,6 +87,20 @@ func BenchmarkPigeonJSONMemo(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		if _, err := Parse("", d, Memoize(true)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPigeonJSONOptimized(b *testing.B) {
+	d, err := ioutil.ReadFile("testdata/github-octokit-repos.json")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := optimized.Parse("", d); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -1,0 +1,1477 @@
+// Package json parses JSON as defined by [1].
+//
+// BUGS: the escaped forward solidus (`\/`) is not currently handled.
+//
+// [1]: http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
+package json
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+func toIfaceSlice(v interface{}) []interface{} {
+	if v == nil {
+		return nil
+	}
+	return v.([]interface{})
+}
+
+var g = &grammar{
+	rules: []*rule{
+		{
+			name: "JSON",
+			pos:  position{line: 17, col: 1, offset: 347},
+			expr: &actionExpr{
+				pos: position{line: 17, col: 8, offset: 356},
+				run: (*parser).callonJSON1,
+				expr: &seqExpr{
+					pos: position{line: 17, col: 8, offset: 356},
+					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 17, col: 8, offset: 356},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 17, col: 10, offset: 358},
+							label: "vals",
+							expr: &oneOrMoreExpr{
+								pos: position{line: 17, col: 15, offset: 363},
+								expr: &ruleRefExpr{
+									pos:  position{line: 17, col: 15, offset: 363},
+									name: "Value",
+								},
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 17, col: 22, offset: 370},
+							name: "EOF",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Value",
+			pos:  position{line: 29, col: 1, offset: 561},
+			expr: &actionExpr{
+				pos: position{line: 29, col: 9, offset: 571},
+				run: (*parser).callonValue1,
+				expr: &seqExpr{
+					pos: position{line: 29, col: 9, offset: 571},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 29, col: 9, offset: 571},
+							label: "val",
+							expr: &choiceExpr{
+								pos: position{line: 29, col: 15, offset: 577},
+								alternatives: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 29, col: 15, offset: 577},
+										name: "Object",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 29, col: 24, offset: 586},
+										name: "Array",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 29, col: 32, offset: 594},
+										name: "Number",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 29, col: 41, offset: 603},
+										name: "String",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 29, col: 50, offset: 612},
+										name: "Bool",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 29, col: 57, offset: 619},
+										name: "Null",
+									},
+								},
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 29, col: 64, offset: 626},
+							name: "_",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Object",
+			pos:  position{line: 33, col: 1, offset: 653},
+			expr: &actionExpr{
+				pos: position{line: 33, col: 10, offset: 664},
+				run: (*parser).callonObject1,
+				expr: &seqExpr{
+					pos: position{line: 33, col: 10, offset: 664},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 33, col: 10, offset: 664},
+							val:        "{",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 33, col: 14, offset: 668},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 33, col: 16, offset: 670},
+							label: "vals",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 33, col: 21, offset: 675},
+								expr: &seqExpr{
+									pos: position{line: 33, col: 23, offset: 677},
+									exprs: []interface{}{
+										&ruleRefExpr{
+											pos:  position{line: 33, col: 23, offset: 677},
+											name: "String",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 33, col: 30, offset: 684},
+											name: "_",
+										},
+										&litMatcher{
+											pos:        position{line: 33, col: 32, offset: 686},
+											val:        ":",
+											ignoreCase: false,
+										},
+										&ruleRefExpr{
+											pos:  position{line: 33, col: 36, offset: 690},
+											name: "_",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 33, col: 38, offset: 692},
+											name: "Value",
+										},
+										&zeroOrMoreExpr{
+											pos: position{line: 33, col: 44, offset: 698},
+											expr: &seqExpr{
+												pos: position{line: 33, col: 46, offset: 700},
+												exprs: []interface{}{
+													&litMatcher{
+														pos:        position{line: 33, col: 46, offset: 700},
+														val:        ",",
+														ignoreCase: false,
+													},
+													&ruleRefExpr{
+														pos:  position{line: 33, col: 50, offset: 704},
+														name: "_",
+													},
+													&ruleRefExpr{
+														pos:  position{line: 33, col: 52, offset: 706},
+														name: "String",
+													},
+													&ruleRefExpr{
+														pos:  position{line: 33, col: 59, offset: 713},
+														name: "_",
+													},
+													&litMatcher{
+														pos:        position{line: 33, col: 61, offset: 715},
+														val:        ":",
+														ignoreCase: false,
+													},
+													&ruleRefExpr{
+														pos:  position{line: 33, col: 65, offset: 719},
+														name: "_",
+													},
+													&ruleRefExpr{
+														pos:  position{line: 33, col: 67, offset: 721},
+														name: "Value",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						&litMatcher{
+							pos:        position{line: 33, col: 79, offset: 733},
+							val:        "}",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Array",
+			pos:  position{line: 48, col: 1, offset: 1075},
+			expr: &actionExpr{
+				pos: position{line: 48, col: 9, offset: 1085},
+				run: (*parser).callonArray1,
+				expr: &seqExpr{
+					pos: position{line: 48, col: 9, offset: 1085},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 48, col: 9, offset: 1085},
+							val:        "[",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 48, col: 13, offset: 1089},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 48, col: 15, offset: 1091},
+							label: "vals",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 48, col: 20, offset: 1096},
+								expr: &seqExpr{
+									pos: position{line: 48, col: 22, offset: 1098},
+									exprs: []interface{}{
+										&ruleRefExpr{
+											pos:  position{line: 48, col: 22, offset: 1098},
+											name: "Value",
+										},
+										&zeroOrMoreExpr{
+											pos: position{line: 48, col: 28, offset: 1104},
+											expr: &seqExpr{
+												pos: position{line: 48, col: 30, offset: 1106},
+												exprs: []interface{}{
+													&litMatcher{
+														pos:        position{line: 48, col: 30, offset: 1106},
+														val:        ",",
+														ignoreCase: false,
+													},
+													&ruleRefExpr{
+														pos:  position{line: 48, col: 34, offset: 1110},
+														name: "_",
+													},
+													&ruleRefExpr{
+														pos:  position{line: 48, col: 36, offset: 1112},
+														name: "Value",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						&litMatcher{
+							pos:        position{line: 48, col: 48, offset: 1124},
+							val:        "]",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Number",
+			pos:  position{line: 62, col: 1, offset: 1430},
+			expr: &actionExpr{
+				pos: position{line: 62, col: 10, offset: 1441},
+				run: (*parser).callonNumber1,
+				expr: &seqExpr{
+					pos: position{line: 62, col: 10, offset: 1441},
+					exprs: []interface{}{
+						&zeroOrOneExpr{
+							pos: position{line: 62, col: 10, offset: 1441},
+							expr: &litMatcher{
+								pos:        position{line: 62, col: 10, offset: 1441},
+								val:        "-",
+								ignoreCase: false,
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 62, col: 15, offset: 1446},
+							name: "Integer",
+						},
+						&zeroOrOneExpr{
+							pos: position{line: 62, col: 23, offset: 1454},
+							expr: &seqExpr{
+								pos: position{line: 62, col: 25, offset: 1456},
+								exprs: []interface{}{
+									&litMatcher{
+										pos:        position{line: 62, col: 25, offset: 1456},
+										val:        ".",
+										ignoreCase: false,
+									},
+									&oneOrMoreExpr{
+										pos: position{line: 62, col: 29, offset: 1460},
+										expr: &ruleRefExpr{
+											pos:  position{line: 62, col: 29, offset: 1460},
+											name: "DecimalDigit",
+										},
+									},
+								},
+							},
+						},
+						&zeroOrOneExpr{
+							pos: position{line: 62, col: 46, offset: 1477},
+							expr: &ruleRefExpr{
+								pos:  position{line: 62, col: 46, offset: 1477},
+								name: "Exponent",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Integer",
+			pos:  position{line: 68, col: 1, offset: 1632},
+			expr: &choiceExpr{
+				pos: position{line: 68, col: 11, offset: 1644},
+				alternatives: []interface{}{
+					&litMatcher{
+						pos:        position{line: 68, col: 11, offset: 1644},
+						val:        "0",
+						ignoreCase: false,
+					},
+					&seqExpr{
+						pos: position{line: 68, col: 17, offset: 1650},
+						exprs: []interface{}{
+							&ruleRefExpr{
+								pos:  position{line: 68, col: 17, offset: 1650},
+								name: "NonZeroDecimalDigit",
+							},
+							&zeroOrMoreExpr{
+								pos: position{line: 68, col: 37, offset: 1670},
+								expr: &ruleRefExpr{
+									pos:  position{line: 68, col: 37, offset: 1670},
+									name: "DecimalDigit",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Exponent",
+			pos:  position{line: 70, col: 1, offset: 1685},
+			expr: &seqExpr{
+				pos: position{line: 70, col: 12, offset: 1698},
+				exprs: []interface{}{
+					&litMatcher{
+						pos:        position{line: 70, col: 12, offset: 1698},
+						val:        "e",
+						ignoreCase: true,
+					},
+					&zeroOrOneExpr{
+						pos: position{line: 70, col: 17, offset: 1703},
+						expr: &charClassMatcher{
+							pos:        position{line: 70, col: 17, offset: 1703},
+							val:        "[+-]",
+							chars:      []rune{'+', '-'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+					},
+					&oneOrMoreExpr{
+						pos: position{line: 70, col: 23, offset: 1709},
+						expr: &ruleRefExpr{
+							pos:  position{line: 70, col: 23, offset: 1709},
+							name: "DecimalDigit",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "String",
+			pos:  position{line: 72, col: 1, offset: 1724},
+			expr: &actionExpr{
+				pos: position{line: 72, col: 10, offset: 1735},
+				run: (*parser).callonString1,
+				expr: &seqExpr{
+					pos: position{line: 72, col: 10, offset: 1735},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 72, col: 10, offset: 1735},
+							val:        "\"",
+							ignoreCase: false,
+						},
+						&zeroOrMoreExpr{
+							pos: position{line: 72, col: 14, offset: 1739},
+							expr: &choiceExpr{
+								pos: position{line: 72, col: 16, offset: 1741},
+								alternatives: []interface{}{
+									&seqExpr{
+										pos: position{line: 72, col: 16, offset: 1741},
+										exprs: []interface{}{
+											&notExpr{
+												pos: position{line: 72, col: 16, offset: 1741},
+												expr: &ruleRefExpr{
+													pos:  position{line: 72, col: 17, offset: 1742},
+													name: "EscapedChar",
+												},
+											},
+											&anyMatcher{
+												line: 72, col: 29, offset: 1754,
+											},
+										},
+									},
+									&seqExpr{
+										pos: position{line: 72, col: 33, offset: 1758},
+										exprs: []interface{}{
+											&litMatcher{
+												pos:        position{line: 72, col: 33, offset: 1758},
+												val:        "\\",
+												ignoreCase: false,
+											},
+											&ruleRefExpr{
+												pos:  position{line: 72, col: 38, offset: 1763},
+												name: "EscapeSequence",
+											},
+										},
+									},
+								},
+							},
+						},
+						&litMatcher{
+							pos:        position{line: 72, col: 56, offset: 1781},
+							val:        "\"",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "EscapedChar",
+			pos:  position{line: 78, col: 1, offset: 1953},
+			expr: &charClassMatcher{
+				pos:        position{line: 78, col: 15, offset: 1969},
+				val:        "[\\x00-\\x1f\"\\\\]",
+				chars:      []rune{'"', '\\'},
+				ranges:     []rune{'\x00', '\x1f'},
+				ignoreCase: false,
+				inverted:   false,
+			},
+		},
+		{
+			name: "EscapeSequence",
+			pos:  position{line: 80, col: 1, offset: 1985},
+			expr: &choiceExpr{
+				pos: position{line: 80, col: 18, offset: 2004},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 80, col: 18, offset: 2004},
+						name: "SingleCharEscape",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 80, col: 37, offset: 2023},
+						name: "UnicodeEscape",
+					},
+				},
+			},
+		},
+		{
+			name: "SingleCharEscape",
+			pos:  position{line: 82, col: 1, offset: 2038},
+			expr: &charClassMatcher{
+				pos:        position{line: 82, col: 20, offset: 2059},
+				val:        "[\"\\\\/bfnrt]",
+				chars:      []rune{'"', '\\', '/', 'b', 'f', 'n', 'r', 't'},
+				ignoreCase: false,
+				inverted:   false,
+			},
+		},
+		{
+			name: "UnicodeEscape",
+			pos:  position{line: 84, col: 1, offset: 2072},
+			expr: &seqExpr{
+				pos: position{line: 84, col: 17, offset: 2090},
+				exprs: []interface{}{
+					&litMatcher{
+						pos:        position{line: 84, col: 17, offset: 2090},
+						val:        "u",
+						ignoreCase: false,
+					},
+					&ruleRefExpr{
+						pos:  position{line: 84, col: 21, offset: 2094},
+						name: "HexDigit",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 84, col: 30, offset: 2103},
+						name: "HexDigit",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 84, col: 39, offset: 2112},
+						name: "HexDigit",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 84, col: 48, offset: 2121},
+						name: "HexDigit",
+					},
+				},
+			},
+		},
+		{
+			name: "DecimalDigit",
+			pos:  position{line: 86, col: 1, offset: 2131},
+			expr: &charClassMatcher{
+				pos:        position{line: 86, col: 16, offset: 2148},
+				val:        "[0-9]",
+				ranges:     []rune{'0', '9'},
+				ignoreCase: false,
+				inverted:   false,
+			},
+		},
+		{
+			name: "NonZeroDecimalDigit",
+			pos:  position{line: 88, col: 1, offset: 2155},
+			expr: &charClassMatcher{
+				pos:        position{line: 88, col: 23, offset: 2179},
+				val:        "[1-9]",
+				ranges:     []rune{'1', '9'},
+				ignoreCase: false,
+				inverted:   false,
+			},
+		},
+		{
+			name: "HexDigit",
+			pos:  position{line: 90, col: 1, offset: 2186},
+			expr: &charClassMatcher{
+				pos:        position{line: 90, col: 12, offset: 2199},
+				val:        "[0-9a-f]i",
+				ranges:     []rune{'0', '9', 'a', 'f'},
+				ignoreCase: true,
+				inverted:   false,
+			},
+		},
+		{
+			name: "Bool",
+			pos:  position{line: 92, col: 1, offset: 2210},
+			expr: &choiceExpr{
+				pos: position{line: 92, col: 8, offset: 2219},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 92, col: 8, offset: 2219},
+						run: (*parser).callonBool2,
+						expr: &litMatcher{
+							pos:        position{line: 92, col: 8, offset: 2219},
+							val:        "true",
+							ignoreCase: false,
+						},
+					},
+					&actionExpr{
+						pos: position{line: 92, col: 38, offset: 2249},
+						run: (*parser).callonBool4,
+						expr: &litMatcher{
+							pos:        position{line: 92, col: 38, offset: 2249},
+							val:        "false",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Null",
+			pos:  position{line: 94, col: 1, offset: 2280},
+			expr: &actionExpr{
+				pos: position{line: 94, col: 8, offset: 2289},
+				run: (*parser).callonNull1,
+				expr: &litMatcher{
+					pos:        position{line: 94, col: 8, offset: 2289},
+					val:        "null",
+					ignoreCase: false,
+				},
+			},
+		},
+		{
+			name:        "_",
+			displayName: "\"whitespace\"",
+			pos:         position{line: 96, col: 1, offset: 2317},
+			expr: &zeroOrMoreExpr{
+				pos: position{line: 96, col: 18, offset: 2336},
+				expr: &charClassMatcher{
+					pos:        position{line: 96, col: 18, offset: 2336},
+					val:        "[ \\t\\r\\n]",
+					chars:      []rune{' ', '\t', '\r', '\n'},
+					ignoreCase: false,
+					inverted:   false,
+				},
+			},
+		},
+		{
+			name: "EOF",
+			pos:  position{line: 98, col: 1, offset: 2348},
+			expr: &notExpr{
+				pos: position{line: 98, col: 7, offset: 2356},
+				expr: &anyMatcher{
+					line: 98, col: 8, offset: 2357,
+				},
+			},
+		},
+	},
+}
+
+func (c *current) onJSON1(vals interface{}) (interface{}, error) {
+	valsSl := toIfaceSlice(vals)
+	switch len(valsSl) {
+	case 0:
+		return nil, nil
+	case 1:
+		return valsSl[0], nil
+	default:
+		return valsSl, nil
+	}
+}
+
+func (p *parser) callonJSON1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJSON1(stack["vals"])
+}
+
+func (c *current) onValue1(val interface{}) (interface{}, error) {
+	return val, nil
+}
+
+func (p *parser) callonValue1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onValue1(stack["val"])
+}
+
+func (c *current) onObject1(vals interface{}) (interface{}, error) {
+	res := make(map[string]interface{})
+	valsSl := toIfaceSlice(vals)
+	if len(valsSl) == 0 {
+		return res, nil
+	}
+	res[valsSl[0].(string)] = valsSl[4]
+	restSl := toIfaceSlice(valsSl[5])
+	for _, v := range restSl {
+		vSl := toIfaceSlice(v)
+		res[vSl[2].(string)] = vSl[6]
+	}
+	return res, nil
+}
+
+func (p *parser) callonObject1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onObject1(stack["vals"])
+}
+
+func (c *current) onArray1(vals interface{}) (interface{}, error) {
+	valsSl := toIfaceSlice(vals)
+	if len(valsSl) == 0 {
+		return []interface{}{}, nil
+	}
+	res := []interface{}{valsSl[0]}
+	restSl := toIfaceSlice(valsSl[1])
+	for _, v := range restSl {
+		vSl := toIfaceSlice(v)
+		res = append(res, vSl[2])
+	}
+	return res, nil
+}
+
+func (p *parser) callonArray1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onArray1(stack["vals"])
+}
+
+func (c *current) onNumber1() (interface{}, error) {
+	// JSON numbers have the same syntax as Go's, and are parseable using
+	// strconv.
+	return strconv.ParseFloat(string(c.text), 64)
+}
+
+func (p *parser) callonNumber1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNumber1()
+}
+
+func (c *current) onString1() (interface{}, error) {
+	// TODO : the forward slash (solidus) is not a valid escape in Go, it will
+	// fail if there's one in the string
+	return strconv.Unquote(string(c.text))
+}
+
+func (p *parser) callonString1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onString1()
+}
+
+func (c *current) onBool2() (interface{}, error) {
+	return true, nil
+}
+
+func (p *parser) callonBool2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onBool2()
+}
+
+func (c *current) onBool4() (interface{}, error) {
+	return false, nil
+}
+
+func (p *parser) callonBool4() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onBool4()
+}
+
+func (c *current) onNull1() (interface{}, error) {
+	return nil, nil
+}
+
+func (p *parser) callonNull1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNull1()
+}
+
+var (
+	// errNoRule is returned when the grammar to parse has no rule.
+	errNoRule = errors.New("grammar has no rule")
+
+	// errInvalidEncoding is returned when the source is not properly
+	// utf8-encoded.
+	errInvalidEncoding = errors.New("invalid encoding")
+)
+
+// Option is a function that can set an option on the parser. It returns
+// the previous setting as an Option.
+type Option func(*parser) Option
+
+// Recover creates an Option to set the recover flag to b. When set to
+// true, this causes the parser to recover from panics and convert it
+// to an error. Setting it to false can be useful while debugging to
+// access the full stack trace.
+//
+// The default is true.
+func Recover(b bool) Option {
+	return func(p *parser) Option {
+		old := p.recover
+		p.recover = b
+		return Recover(old)
+	}
+}
+
+// ParseFile parses the file identified by filename.
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = f.Close()
+	}()
+	return ParseReader(filename, f, opts...)
+}
+
+// ParseReader parses the data from r using filename as information in the
+// error messages.
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return Parse(filename, b, opts...)
+}
+
+// Parse parses the data from b using filename as information in the
+// error messages.
+func Parse(filename string, b []byte, opts ...Option) (interface{}, error) {
+	return newParser(filename, b, opts...).parse(g)
+}
+
+// position records a position in the text.
+type position struct {
+	line, col, offset int
+}
+
+func (p position) String() string {
+	return fmt.Sprintf("%d:%d [%d]", p.line, p.col, p.offset)
+}
+
+// savepoint stores all state required to go back to this point in the
+// parser.
+type savepoint struct {
+	position
+	rn rune
+	w  int
+}
+
+type current struct {
+	pos  position // start position of the match
+	text []byte   // raw text of the match
+}
+
+// the AST types...
+
+type grammar struct {
+	pos   position
+	rules []*rule
+}
+
+type rule struct {
+	pos         position
+	name        string
+	displayName string
+	expr        interface{}
+}
+
+type choiceExpr struct {
+	pos          position
+	alternatives []interface{}
+}
+
+type actionExpr struct {
+	pos  position
+	expr interface{}
+	run  func(*parser) (interface{}, error)
+}
+
+type seqExpr struct {
+	pos   position
+	exprs []interface{}
+}
+
+type labeledExpr struct {
+	pos   position
+	label string
+	expr  interface{}
+}
+
+type expr struct {
+	pos  position
+	expr interface{}
+}
+
+type andExpr expr
+type notExpr expr
+type zeroOrOneExpr expr
+type zeroOrMoreExpr expr
+type oneOrMoreExpr expr
+
+type ruleRefExpr struct {
+	pos  position
+	name string
+}
+
+type andCodeExpr struct {
+	pos position
+	run func(*parser) (bool, error)
+}
+
+type notCodeExpr struct {
+	pos position
+	run func(*parser) (bool, error)
+}
+
+type litMatcher struct {
+	pos        position
+	val        string
+	ignoreCase bool
+}
+
+type charClassMatcher struct {
+	pos        position
+	val        string
+	chars      []rune
+	ranges     []rune
+	classes    []*unicode.RangeTable
+	ignoreCase bool
+	inverted   bool
+}
+
+type anyMatcher position
+
+// errList cumulates the errors found by the parser.
+type errList []error
+
+func (e *errList) add(err error) {
+	*e = append(*e, err)
+}
+
+func (e errList) err() error {
+	if len(e) == 0 {
+		return nil
+	}
+	e.dedupe()
+	return e
+}
+
+func (e *errList) dedupe() {
+	var cleaned []error
+	set := make(map[string]bool)
+	for _, err := range *e {
+		if msg := err.Error(); !set[msg] {
+			set[msg] = true
+			cleaned = append(cleaned, err)
+		}
+	}
+	*e = cleaned
+}
+
+func (e errList) Error() string {
+	switch len(e) {
+	case 0:
+		return ""
+	case 1:
+		return e[0].Error()
+	default:
+		var buf bytes.Buffer
+
+		for i, err := range e {
+			if i > 0 {
+				buf.WriteRune('\n')
+			}
+			buf.WriteString(err.Error())
+		}
+		return buf.String()
+	}
+}
+
+// parserError wraps an error with a prefix indicating the rule in which
+// the error occurred. The original error is stored in the Inner field.
+type parserError struct {
+	Inner    error
+	pos      position
+	prefix   string
+	expected []string
+}
+
+// Error returns the error message.
+func (p *parserError) Error() string {
+	return p.prefix + ": " + p.Inner.Error()
+}
+
+// newParser creates a parser with the specified input source and options.
+func newParser(filename string, b []byte, opts ...Option) *parser {
+	p := &parser{
+		filename:        filename,
+		errs:            new(errList),
+		data:            b,
+		pt:              savepoint{position: position{line: 1}},
+		recover:         true,
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make(map[string]struct{}),
+	}
+	p.setOptions(opts)
+	return p
+}
+
+// setOptions applies the options to the parser.
+func (p *parser) setOptions(opts []Option) {
+	for _, opt := range opts {
+		opt(p)
+	}
+}
+
+type resultTuple struct {
+	v   interface{}
+	b   bool
+	end savepoint
+}
+
+type parser struct {
+	filename string
+	pt       savepoint
+	cur      current
+
+	data []byte
+	errs *errList
+
+	depth   int
+	recover bool
+
+	// rules table, maps the rule identifier to the rule node
+	rules map[string]*rule
+	// variables stack, map of label to value
+	vstack []map[string]interface{}
+	// rule stack, allows identification of the current rule in errors
+	rstack []*rule
+
+	// parse fail
+	maxFailPos            position
+	maxFailExpected       map[string]struct{}
+	maxFailInvertExpected bool
+}
+
+// push a variable set on the vstack.
+func (p *parser) pushV() {
+	if cap(p.vstack) == len(p.vstack) {
+		// create new empty slot in the stack
+		p.vstack = append(p.vstack, nil)
+	} else {
+		// slice to 1 more
+		p.vstack = p.vstack[:len(p.vstack)+1]
+	}
+
+	// get the last args set
+	m := p.vstack[len(p.vstack)-1]
+	if m != nil && len(m) == 0 {
+		// empty map, all good
+		return
+	}
+
+	m = make(map[string]interface{})
+	p.vstack[len(p.vstack)-1] = m
+}
+
+// pop a variable set from the vstack.
+func (p *parser) popV() {
+	// if the map is not empty, clear it
+	m := p.vstack[len(p.vstack)-1]
+	if len(m) > 0 {
+		// GC that map
+		p.vstack[len(p.vstack)-1] = nil
+	}
+	p.vstack = p.vstack[:len(p.vstack)-1]
+}
+
+func (p *parser) addErr(err error) {
+	p.addErrAt(err, p.pt.position, []string{})
+}
+
+func (p *parser) addErrAt(err error, pos position, expected []string) {
+	var buf bytes.Buffer
+	if p.filename != "" {
+		buf.WriteString(p.filename)
+	}
+	if buf.Len() > 0 {
+		buf.WriteString(":")
+	}
+	buf.WriteString(fmt.Sprintf("%d:%d (%d)", pos.line, pos.col, pos.offset))
+	if len(p.rstack) > 0 {
+		if buf.Len() > 0 {
+			buf.WriteString(": ")
+		}
+		rule := p.rstack[len(p.rstack)-1]
+		if rule.displayName != "" {
+			buf.WriteString("rule " + rule.displayName)
+		} else {
+			buf.WriteString("rule " + rule.name)
+		}
+	}
+	pe := &parserError{Inner: err, pos: pos, prefix: buf.String(), expected: expected}
+	p.errs.add(pe)
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = make(map[string]struct{})
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected[want] = struct{}{}
+	}
+}
+
+// read advances the parser to the next rune.
+func (p *parser) read() {
+	p.pt.offset += p.pt.w
+	rn, n := utf8.DecodeRune(p.data[p.pt.offset:])
+	p.pt.rn = rn
+	p.pt.w = n
+	p.pt.col++
+	if rn == '\n' {
+		p.pt.line++
+		p.pt.col = 0
+	}
+
+	if rn == utf8.RuneError {
+		if n == 1 {
+			p.addErr(errInvalidEncoding)
+		}
+	}
+}
+
+// restore parser position to the savepoint pt.
+func (p *parser) restore(pt savepoint) {
+	if pt.offset == p.pt.offset {
+		return
+	}
+	p.pt = pt
+}
+
+// get the slice of bytes from the savepoint start to the current position.
+func (p *parser) sliceFrom(start savepoint) []byte {
+	return p.data[start.position.offset:p.pt.position.offset]
+}
+
+func (p *parser) buildRulesTable(g *grammar) {
+	p.rules = make(map[string]*rule, len(g.rules))
+	for _, r := range g.rules {
+		p.rules[r.name] = r
+	}
+}
+
+func (p *parser) parse(g *grammar) (val interface{}, err error) {
+	if len(g.rules) == 0 {
+		p.addErr(errNoRule)
+		return nil, p.errs.err()
+	}
+
+	// TODO : not super critical but this could be generated
+	p.buildRulesTable(g)
+
+	if p.recover {
+		// panic can be used in action code to stop parsing immediately
+		// and return the panic as an error.
+		defer func() {
+			if e := recover(); e != nil {
+				val = nil
+				switch e := e.(type) {
+				case error:
+					p.addErr(e)
+				default:
+					p.addErr(fmt.Errorf("%v", e))
+				}
+				err = p.errs.err()
+			}
+		}()
+	}
+
+	// start rule is rule [0]
+	p.read() // advance to first rune
+	val, ok := p.parseRule(g.rules[0])
+	if !ok {
+		if len(*p.errs) == 0 {
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			expected := make([]string, 0, len(p.maxFailExpected))
+			eof := false
+			if _, ok := p.maxFailExpected["!."]; ok {
+				delete(p.maxFailExpected, "!.")
+				eof = true
+			}
+			for k := range p.maxFailExpected {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			if eof {
+				expected = append(expected, "EOF")
+			}
+			p.addErrAt(errors.New("no match found, expected: "+listJoin(expected, ", ", "or")), p.maxFailPos, expected)
+		}
+		return nil, p.errs.err()
+	}
+	return val, p.errs.err()
+}
+
+func listJoin(list []string, sep string, lastSep string) string {
+	switch len(list) {
+	case 0:
+		return ""
+	case 1:
+		return list[0]
+	default:
+		return fmt.Sprintf("%s %s %s", strings.Join(list[:len(list)-1], sep), lastSep, list[len(list)-1])
+	}
+}
+
+func (p *parser) parseRule(rule *rule) (interface{}, bool) {
+	p.rstack = append(p.rstack, rule)
+	p.pushV()
+	val, ok := p.parseExpr(rule.expr)
+	p.popV()
+	p.rstack = p.rstack[:len(p.rstack)-1]
+	return val, ok
+}
+
+func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
+	var val interface{}
+	var ok bool
+	switch expr := expr.(type) {
+	case *actionExpr:
+		val, ok = p.parseActionExpr(expr)
+	case *andCodeExpr:
+		val, ok = p.parseAndCodeExpr(expr)
+	case *andExpr:
+		val, ok = p.parseAndExpr(expr)
+	case *anyMatcher:
+		val, ok = p.parseAnyMatcher(expr)
+	case *charClassMatcher:
+		val, ok = p.parseCharClassMatcher(expr)
+	case *choiceExpr:
+		val, ok = p.parseChoiceExpr(expr)
+	case *labeledExpr:
+		val, ok = p.parseLabeledExpr(expr)
+	case *litMatcher:
+		val, ok = p.parseLitMatcher(expr)
+	case *notCodeExpr:
+		val, ok = p.parseNotCodeExpr(expr)
+	case *notExpr:
+		val, ok = p.parseNotExpr(expr)
+	case *oneOrMoreExpr:
+		val, ok = p.parseOneOrMoreExpr(expr)
+	case *ruleRefExpr:
+		val, ok = p.parseRuleRefExpr(expr)
+	case *seqExpr:
+		val, ok = p.parseSeqExpr(expr)
+	case *zeroOrMoreExpr:
+		val, ok = p.parseZeroOrMoreExpr(expr)
+	case *zeroOrOneExpr:
+		val, ok = p.parseZeroOrOneExpr(expr)
+	default:
+		panic(fmt.Sprintf("unknown expression type %T", expr))
+	}
+	return val, ok
+}
+
+func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
+	start := p.pt
+	val, ok := p.parseExpr(act.expr)
+	if ok {
+		p.cur.pos = start.position
+		p.cur.text = p.sliceFrom(start)
+		actVal, err := act.run(p)
+		if err != nil {
+			p.addErrAt(err, start.position, []string{})
+		}
+		val = actVal
+	}
+	return val, ok
+}
+
+func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
+	ok, err := and.run(p)
+	if err != nil {
+		p.addErr(err)
+	}
+	return nil, ok
+}
+
+func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
+	pt := p.pt
+	p.pushV()
+	_, ok := p.parseExpr(and.expr)
+	p.popV()
+	p.restore(pt)
+	return nil, ok
+}
+
+func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
+	if p.pt.rn != utf8.RuneError {
+		start := p.pt
+		p.read()
+		p.failAt(true, start.position, ".")
+		return p.sliceFrom(start), true
+	}
+	p.failAt(false, p.pt.position, ".")
+	return nil, false
+}
+
+func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
+	cur := p.pt.rn
+	start := p.pt
+	// can't match EOF
+	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
+		return nil, false
+	}
+	if chr.ignoreCase {
+		cur = unicode.ToLower(cur)
+	}
+
+	// try to match in the list of available chars
+	for _, rn := range chr.chars {
+		if rn == cur {
+			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
+				return nil, false
+			}
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+	}
+
+	// try to match in the list of ranges
+	for i := 0; i < len(chr.ranges); i += 2 {
+		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
+			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
+				return nil, false
+			}
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+	}
+
+	// try to match in the list of Unicode classes
+	for _, cl := range chr.classes {
+		if unicode.Is(cl, cur) {
+			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
+				return nil, false
+			}
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+	}
+
+	if chr.inverted {
+		p.read()
+		p.failAt(true, start.position, chr.val)
+		return p.sliceFrom(start), true
+	}
+	p.failAt(false, start.position, chr.val)
+	return nil, false
+}
+
+func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
+	for _, alt := range ch.alternatives {
+		p.pushV()
+		val, ok := p.parseExpr(alt)
+		p.popV()
+		if ok {
+			return val, ok
+		}
+	}
+	return nil, false
+}
+
+func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
+	p.pushV()
+	val, ok := p.parseExpr(lab.expr)
+	p.popV()
+	if ok && lab.label != "" {
+		m := p.vstack[len(p.vstack)-1]
+		m[lab.label] = val
+	}
+	return val, ok
+}
+
+func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
+	start := p.pt
+	for _, want := range lit.val {
+		cur := p.pt.rn
+		if lit.ignoreCase {
+			cur = unicode.ToLower(cur)
+		}
+		if cur != want {
+			p.failAt(false, start.position, val)
+			p.restore(start)
+			return nil, false
+		}
+		p.read()
+	}
+	p.failAt(true, start.position, val)
+	return p.sliceFrom(start), true
+}
+
+func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
+	ok, err := not.run(p)
+	if err != nil {
+		p.addErr(err)
+	}
+	return nil, !ok
+}
+
+func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
+	pt := p.pt
+	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
+	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
+	p.popV()
+	p.restore(pt)
+	return nil, !ok
+}
+
+func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
+	var vals []interface{}
+
+	for {
+		p.pushV()
+		val, ok := p.parseExpr(expr.expr)
+		p.popV()
+		if !ok {
+			if len(vals) == 0 {
+				// did not match once, no match
+				return nil, false
+			}
+			return vals, true
+		}
+		vals = append(vals, val)
+	}
+}
+
+func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
+	if ref.name == "" {
+		panic(fmt.Sprintf("%s: invalid rule: missing name", ref.pos))
+	}
+
+	rule := p.rules[ref.name]
+	if rule == nil {
+		p.addErr(fmt.Errorf("undefined rule: %s", ref.name))
+		return nil, false
+	}
+	return p.parseRule(rule)
+}
+
+func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
+	var vals []interface{}
+
+	pt := p.pt
+	for _, expr := range seq.exprs {
+		val, ok := p.parseExpr(expr)
+		if !ok {
+			p.restore(pt)
+			return nil, false
+		}
+		vals = append(vals, val)
+	}
+	return vals, true
+}
+
+func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
+	var vals []interface{}
+
+	for {
+		p.pushV()
+		val, ok := p.parseExpr(expr.expr)
+		p.popV()
+		if !ok {
+			return vals, true
+		}
+		vals = append(vals, val)
+	}
+}
+
+func (p *parser) parseZeroOrOneExpr(expr *zeroOrOneExpr) (interface{}, bool) {
+	p.pushV()
+	val, _ := p.parseExpr(expr.expr)
+	p.popV()
+	// whether it matched or not, consider it a match
+	return val, true
+}

--- a/main.go
+++ b/main.go
@@ -24,14 +24,15 @@ func main() {
 
 	// define command-line flags
 	var (
-		cacheFlag     = fs.Bool("cache", false, "cache parsing results")
-		dbgFlag       = fs.Bool("debug", false, "set debug mode")
-		shortHelpFlag = fs.Bool("h", false, "show help page")
-		longHelpFlag  = fs.Bool("help", false, "show help page")
-		noRecoverFlag = fs.Bool("no-recover", false, "do not recover from panic")
-		outputFlag    = fs.String("o", "", "output file, defaults to stdout")
-		recvrNmFlag   = fs.String("receiver-name", "c", "receiver name for the generated methods")
-		noBuildFlag   = fs.Bool("x", false, "do not build, only parse")
+		cacheFlag          = fs.Bool("cache", false, "cache parsing results")
+		dbgFlag            = fs.Bool("debug", false, "set debug mode")
+		shortHelpFlag      = fs.Bool("h", false, "show help page")
+		longHelpFlag       = fs.Bool("help", false, "show help page")
+		noRecoverFlag      = fs.Bool("no-recover", false, "do not recover from panic")
+		outputFlag         = fs.String("o", "", "output file, defaults to stdout")
+		optimizeParserFlag = fs.Bool("optimize-parser", false, "generate optimized parser without Debug and Memoize options")
+		recvrNmFlag        = fs.String("receiver-name", "c", "receiver name for the generated methods")
+		noBuildFlag        = fs.Bool("x", false, "do not build, only parse")
 	)
 
 	fs.Usage = usage
@@ -90,7 +91,8 @@ func main() {
 		outBuf := bytes.NewBuffer([]byte{})
 
 		curNmOpt := builder.ReceiverName(*recvrNmFlag)
-		if err := builder.BuildParser(outBuf, g.(*ast.Grammar), curNmOpt); err != nil {
+		optimizeParser := builder.Optimize(*optimizeParserFlag)
+		if err := builder.BuildParser(outBuf, g.(*ast.Grammar), curNmOpt, optimizeParser); err != nil {
 			fmt.Fprintln(os.Stderr, "build error: ", err)
 			exit(5)
 		}
@@ -142,6 +144,8 @@ the generated code is written to this file instead.
 		when debugging, otherwise the panic is converted to an error.
 	-o OUTPUT_FILE
 		write the generated parser to OUTPUT_FILE. Defaults to stdout.
+	-optimize-parser
+		generate optimized parser without Debug and Memoize options
 	-receiver-name NAME
 		use NAME as for the receiver name of the generated methods
 		for the grammar's code blocks. Defaults to "c".


### PR DESCRIPTION
If the `-optimize-parser` flag is provided to pigeon, the resulting
parser is generated without the the Debug and Memoize options.
This saves a few cpu cycles, when using the generated parser,
because some checks for those options are not present.