### PR TITLE
Add `-optimize-basic-latin' parser optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ $(BUILDER_DIR)/generated_static_code.go: $(BUILDER_DIR)/static_code.go $(BINDIR)
 	$(BINDIR)/static_code_generator $(BUILDER_DIR)/static_code.go $@ staticCode
 
 $(BUILDER_DIR)/generated_static_code_range_table.go: $(BUILDER_DIR)/static_code_range_table.go $(BINDIR)/static_code_generator
-	$(BINDIR)/static_code_generator $(BUILDER_DIR)/static_code_range_table.go $@ rangeTable
+	$(BINDIR)/static_code_generator $(BUILDER_DIR)/static_code_range_table.go $@ rangeTable0
 
 $(BOOTSTRAP_GRAMMAR):
 $(PIGEON_GRAMMAR):
@@ -72,7 +72,7 @@ $(EXAMPLES_DIR)/json/json.go: $(EXAMPLES_DIR)/json/json.peg $(EXAMPLES_DIR)/json
 	$(BINDIR)/pigeon $< > $@
 
 $(EXAMPLES_DIR)/json/optimized/json.go: $(EXAMPLES_DIR)/json/json.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon -optimize-parser $< > $@
+	$(BINDIR)/pigeon -optimize-parser -optimize-basic-latin $< > $@
 
 $(EXAMPLES_DIR)/calculator/calculator.go: $(EXAMPLES_DIR)/calculator/calculator.peg $(BINDIR)/pigeon
 	$(BINDIR)/pigeon $< > $@

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2353,13 +2353,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -2877,11 +2878,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -66,6 +66,18 @@ func Optimize(optimize bool) Option {
 	}
 }
 
+// BasicLatinLookupTable returns an option that specifies the basicLatinLookup option
+// If basicLatinLookup is true, a lookup slice for the first 128 chars of
+// the Unicode table (Basic Latin) is generated for each CharClassMatcher
+// to increase the character matching.
+func BasicLatinLookupTable(basicLatinLookupTable bool) Option {
+	return func(b *builder) Option {
+		prev := b.basicLatinLookupTable
+		b.basicLatinLookupTable = basicLatinLookupTable
+		return BasicLatinLookupTable(prev)
+	}
+}
+
 // BuildParser builds the PEG parser using the provider grammar. The code is
 // written to the specified w.
 func BuildParser(w io.Writer, g *ast.Grammar, opts ...Option) error {
@@ -79,8 +91,9 @@ type builder struct {
 	err error
 
 	// options
-	recvName string
-	optimize bool
+	recvName              string
+	optimize              bool
+	basicLatinLookupTable bool
 
 	ruleName  string
 	exprIndex int
@@ -278,9 +291,52 @@ func (b *builder) writeCharClassMatcher(ch *ast.CharClassMatcher) {
 		}
 		b.writelnf("},")
 	}
+	if b.basicLatinLookupTable {
+		b.writelnf("\tbasicLatinChars: %#v,", BasicLatinLookup(ch.Chars, ch.Ranges, ch.UnicodeClasses, ch.IgnoreCase))
+	}
 	b.writelnf("\tignoreCase: %t,", ch.IgnoreCase)
 	b.writelnf("\tinverted: %t,", ch.Inverted)
 	b.writelnf("},")
+}
+
+// BasicLatinLookup calculates the decision results for the first 256 characters of the UTF-8 character
+// set for a given set of chars, ranges and unicodeClasses to speedup the CharClassMatcher.
+func BasicLatinLookup(chars, ranges []rune, unicodeClasses []string, ignoreCase bool) (basicLatinChars [128]bool) {
+	for _, rn := range chars {
+		if rn < 128 {
+			basicLatinChars[rn] = true
+			if ignoreCase {
+				if unicode.IsLower(rn) {
+					basicLatinChars[unicode.ToUpper(rn)] = true
+				} else {
+					basicLatinChars[unicode.ToLower(rn)] = true
+				}
+			}
+		}
+	}
+	for i := 0; i < len(ranges); i += 2 {
+		if ranges[i] < 128 {
+			for j := ranges[i]; j < 128 && j <= ranges[i+1]; j++ {
+				basicLatinChars[j] = true
+				if ignoreCase {
+					if unicode.IsLower(j) {
+						basicLatinChars[unicode.ToUpper(j)] = true
+					} else {
+						basicLatinChars[unicode.ToLower(j)] = true
+					}
+				}
+			}
+		}
+	}
+	for _, cl := range unicodeClasses {
+		rt := rangeTable(cl)
+		for r := rune(0); r < 128; r++ {
+			if unicode.Is(rt, r) {
+				basicLatinChars[r] = true
+			}
+		}
+	}
+	return
 }
 
 func (b *builder) writeChoiceExpr(ch *ast.ChoiceExpr) {
@@ -575,9 +631,11 @@ func (b *builder) writeFunc(funcIx int, code *ast.CodeBlock, callTpl, funcTpl st
 func (b *builder) writeStaticCode() {
 	buffer := bytes.NewBufferString("")
 	params := struct {
-		Optimize bool
+		Optimize              bool
+		BasicLatinLookupTable bool
 	}{
-		Optimize: b.optimize,
+		Optimize:              b.optimize,
+		BasicLatinLookupTable: b.basicLatinLookupTable,
 	}
 	t := template.Must(template.New("static_code").Parse(staticCode))
 
@@ -603,7 +661,7 @@ func (b *builder) writeStaticCode() {
 
 	b.writeln(buffer.String())
 	if b.rangeTable {
-		b.writeln(rangeTable)
+		b.writeln(rangeTable0)
 	}
 }
 

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -193,13 +193,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -751,11 +752,25 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	// {{ end }} ==template==
 	cur := p.pt.rn
 	start := p.pt
+
+	// ==template== {{ if .BasicLatinLookupTable }}
+	if cur < 128 {
+		if chr.basicLatinChars[cur] != chr.inverted {
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+		p.failAt(false, start.position, chr.val)
+		return nil, false
+	}
+	// {{ end }} ==template==
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/builder/generated_static_code_range_table.go
+++ b/builder/generated_static_code_range_table.go
@@ -3,7 +3,7 @@
 
 package builder
 
-var rangeTable = `
+var rangeTable0 = `
 func rangeTable(class string) *unicode.RangeTable {
 	if rt, ok := unicode.Categories[class]; ok {
 		return rt

--- a/builder/static_code_range_table.go
+++ b/builder/static_code_range_table.go
@@ -1,6 +1,4 @@
-//go:generate go run ../bootstrap/cmd/static_code_generator/main.go -- $GOFILE generated_$GOFILE rangeTable
-
-// +build static_code
+//go:generate go run ../bootstrap/cmd/static_code_generator/main.go -- $GOFILE generated_$GOFILE rangeTable0
 
 package builder
 

--- a/doc.go
+++ b/doc.go
@@ -42,6 +42,11 @@ The following options can be specified:
 	-o=FILE : string, output file where the generated parser will be
 	written (default: stdout).
 
+	-optimize-basic-latin : boolean, if set, a lookup table for the first 128
+	characters of the Unicode table (Basic Latin) is generated for each character
+	class matcher. This speeds up the parsing, if parsed data mainly consists
+	of characters from this range (default: false).
+
 	-optimize-parser : boolean, if set, the options Debug and Memoize are removed
 	from the resulting parser. This saves a few cpu cycles, when using the
 	generated parser (default: false).

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -631,13 +631,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -1155,11 +1156,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -925,13 +925,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -1449,11 +1450,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -368,11 +368,12 @@ var g = &grammar{
 					&zeroOrOneExpr{
 						pos: position{line: 70, col: 17, offset: 1703},
 						expr: &charClassMatcher{
-							pos:        position{line: 70, col: 17, offset: 1703},
-							val:        "[+-]",
-							chars:      []rune{'+', '-'},
-							ignoreCase: false,
-							inverted:   false,
+							pos:             position{line: 70, col: 17, offset: 1703},
+							val:             "[+-]",
+							chars:           []rune{'+', '-'},
+							basicLatinChars: [128]bool{false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false},
+							ignoreCase:      false,
+							inverted:        false,
 						},
 					},
 					&oneOrMoreExpr{
@@ -449,12 +450,13 @@ var g = &grammar{
 			name: "EscapedChar",
 			pos:  position{line: 78, col: 1, offset: 1953},
 			expr: &charClassMatcher{
-				pos:        position{line: 78, col: 15, offset: 1969},
-				val:        "[\\x00-\\x1f\"\\\\]",
-				chars:      []rune{'"', '\\'},
-				ranges:     []rune{'\x00', '\x1f'},
-				ignoreCase: false,
-				inverted:   false,
+				pos:             position{line: 78, col: 15, offset: 1969},
+				val:             "[\\x00-\\x1f\"\\\\]",
+				chars:           []rune{'"', '\\'},
+				ranges:          []rune{'\x00', '\x1f'},
+				basicLatinChars: [128]bool{true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false},
+				ignoreCase:      false,
+				inverted:        false,
 			},
 		},
 		{
@@ -478,11 +480,12 @@ var g = &grammar{
 			name: "SingleCharEscape",
 			pos:  position{line: 82, col: 1, offset: 2038},
 			expr: &charClassMatcher{
-				pos:        position{line: 82, col: 20, offset: 2059},
-				val:        "[\"\\\\/bfnrt]",
-				chars:      []rune{'"', '\\', '/', 'b', 'f', 'n', 'r', 't'},
-				ignoreCase: false,
-				inverted:   false,
+				pos:             position{line: 82, col: 20, offset: 2059},
+				val:             "[\"\\\\/bfnrt]",
+				chars:           []rune{'"', '\\', '/', 'b', 'f', 'n', 'r', 't'},
+				basicLatinChars: [128]bool{false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, true, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false, true, false, true, false, false, false, false, false, false, false, false, false, false, false},
+				ignoreCase:      false,
+				inverted:        false,
 			},
 		},
 		{
@@ -519,33 +522,36 @@ var g = &grammar{
 			name: "DecimalDigit",
 			pos:  position{line: 86, col: 1, offset: 2131},
 			expr: &charClassMatcher{
-				pos:        position{line: 86, col: 16, offset: 2148},
-				val:        "[0-9]",
-				ranges:     []rune{'0', '9'},
-				ignoreCase: false,
-				inverted:   false,
+				pos:             position{line: 86, col: 16, offset: 2148},
+				val:             "[0-9]",
+				ranges:          []rune{'0', '9'},
+				basicLatinChars: [128]bool{false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false},
+				ignoreCase:      false,
+				inverted:        false,
 			},
 		},
 		{
 			name: "NonZeroDecimalDigit",
 			pos:  position{line: 88, col: 1, offset: 2155},
 			expr: &charClassMatcher{
-				pos:        position{line: 88, col: 23, offset: 2179},
-				val:        "[1-9]",
-				ranges:     []rune{'1', '9'},
-				ignoreCase: false,
-				inverted:   false,
+				pos:             position{line: 88, col: 23, offset: 2179},
+				val:             "[1-9]",
+				ranges:          []rune{'1', '9'},
+				basicLatinChars: [128]bool{false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false},
+				ignoreCase:      false,
+				inverted:        false,
 			},
 		},
 		{
 			name: "HexDigit",
 			pos:  position{line: 90, col: 1, offset: 2186},
 			expr: &charClassMatcher{
-				pos:        position{line: 90, col: 12, offset: 2199},
-				val:        "[0-9a-f]i",
-				ranges:     []rune{'0', '9', 'a', 'f'},
-				ignoreCase: true,
-				inverted:   false,
+				pos:             position{line: 90, col: 12, offset: 2199},
+				val:             "[0-9a-f]i",
+				ranges:          []rune{'0', '9', 'a', 'f'},
+				basicLatinChars: [128]bool{false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, true, true, true, true, true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, true, true, true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false},
+				ignoreCase:      true,
+				inverted:        false,
 			},
 		},
 		{
@@ -595,11 +601,12 @@ var g = &grammar{
 			expr: &zeroOrMoreExpr{
 				pos: position{line: 96, col: 18, offset: 2336},
 				expr: &charClassMatcher{
-					pos:        position{line: 96, col: 18, offset: 2336},
-					val:        "[ \\t\\r\\n]",
-					chars:      []rune{' ', '\t', '\r', '\n'},
-					ignoreCase: false,
-					inverted:   false,
+					pos:             position{line: 96, col: 18, offset: 2336},
+					val:             "[ \\t\\r\\n]",
+					chars:           []rune{' ', '\t', '\r', '\n'},
+					basicLatinChars: [128]bool{false, false, false, false, false, false, false, false, false, true, true, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false},
+					ignoreCase:      false,
+					inverted:        false,
 				},
 			},
 		},
@@ -899,13 +906,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -1306,11 +1314,23 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	cur := p.pt.rn
 	start := p.pt
+
+	if cur < 128 {
+		if chr.basicLatinChars[cur] != chr.inverted {
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+		p.failAt(false, start.position, chr.val)
+		return nil, false
+	}
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/main.go
+++ b/main.go
@@ -24,15 +24,16 @@ func main() {
 
 	// define command-line flags
 	var (
-		cacheFlag          = fs.Bool("cache", false, "cache parsing results")
-		dbgFlag            = fs.Bool("debug", false, "set debug mode")
-		shortHelpFlag      = fs.Bool("h", false, "show help page")
-		longHelpFlag       = fs.Bool("help", false, "show help page")
-		noRecoverFlag      = fs.Bool("no-recover", false, "do not recover from panic")
-		outputFlag         = fs.String("o", "", "output file, defaults to stdout")
-		optimizeParserFlag = fs.Bool("optimize-parser", false, "generate optimized parser without Debug and Memoize options")
-		recvrNmFlag        = fs.String("receiver-name", "c", "receiver name for the generated methods")
-		noBuildFlag        = fs.Bool("x", false, "do not build, only parse")
+		cacheFlag              = fs.Bool("cache", false, "cache parsing results")
+		dbgFlag                = fs.Bool("debug", false, "set debug mode")
+		shortHelpFlag          = fs.Bool("h", false, "show help page")
+		longHelpFlag           = fs.Bool("help", false, "show help page")
+		noRecoverFlag          = fs.Bool("no-recover", false, "do not recover from panic")
+		outputFlag             = fs.String("o", "", "output file, defaults to stdout")
+		optimizeBasicLatinFlag = fs.Bool("optimize-basic-latin", false, "generate optimized parser for Unicode Basic Latin character sets")
+		optimizeParserFlag     = fs.Bool("optimize-parser", false, "generate optimized parser without Debug and Memoize options")
+		recvrNmFlag            = fs.String("receiver-name", "c", "receiver name for the generated methods")
+		noBuildFlag            = fs.Bool("x", false, "do not build, only parse")
 	)
 
 	fs.Usage = usage
@@ -92,7 +93,8 @@ func main() {
 
 		curNmOpt := builder.ReceiverName(*recvrNmFlag)
 		optimizeParser := builder.Optimize(*optimizeParserFlag)
-		if err := builder.BuildParser(outBuf, g.(*ast.Grammar), curNmOpt, optimizeParser); err != nil {
+		basicLatinOptimize := builder.BasicLatinLookupTable(*optimizeBasicLatinFlag)
+		if err := builder.BuildParser(outBuf, g.(*ast.Grammar), curNmOpt, optimizeParser, basicLatinOptimize); err != nil {
 			fmt.Fprintln(os.Stderr, "build error: ", err)
 			exit(5)
 		}
@@ -144,6 +146,8 @@ the generated code is written to this file instead.
 		when debugging, otherwise the panic is converted to an error.
 	-o OUTPUT_FILE
 		write the generated parser to OUTPUT_FILE. Defaults to stdout.
+	-optimize-basic-latin
+		generate optimized parser for Unicode Basic Latin character set
 	-optimize-parser
 		generate optimized parser without Debug and Memoize options
 	-receiver-name NAME

--- a/pigeon.go
+++ b/pigeon.go
@@ -3020,13 +3020,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -3544,11 +3545,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/targeted_test.go
+++ b/targeted_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"testing"
 	"unicode"
+
+	"github.com/mna/pigeon/builder"
 )
 
 func TestParseNoRule(t *testing.T) {
@@ -251,12 +253,13 @@ func TestParseCharClassMatcher(t *testing.T) {
 		}
 
 		got, ok := p.parseCharClassMatcher(&charClassMatcher{
-			val:        tc.val,
-			chars:      tc.chars,
-			ranges:     tc.ranges,
-			classes:    classes,
-			ignoreCase: tc.ic,
-			inverted:   tc.iv,
+			val:             tc.val,
+			chars:           tc.chars,
+			ranges:          tc.ranges,
+			classes:         classes,
+			basicLatinChars: builder.BasicLatinLookup(tc.chars, tc.ranges, tc.classes, tc.ic),
+			ignoreCase:      tc.ic,
+			inverted:        tc.iv,
 		})
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("%s: want %v, got %v", lbl, tc.out, got)

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -362,13 +362,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -886,11 +887,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -760,13 +760,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -1284,11 +1285,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -372,13 +372,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -896,11 +897,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -580,13 +580,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -1104,11 +1105,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -293,13 +293,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -817,11 +818,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/test/issue_12/issue_12.go
+++ b/test/issue_12/issue_12.go
@@ -380,13 +380,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -904,11 +905,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -302,13 +302,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -826,11 +827,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -380,13 +380,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -904,11 +905,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -428,13 +428,14 @@ type litMatcher struct {
 }
 
 type charClassMatcher struct {
-	pos        position
-	val        string
-	chars      []rune
-	ranges     []rune
-	classes    []*unicode.RangeTable
-	ignoreCase bool
-	inverted   bool
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
 }
 
 type anyMatcher position
@@ -952,11 +953,13 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 	cur := p.pt.rn
 	start := p.pt
+
 	// can't match EOF
 	if cur == utf8.RuneError {
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}
+
 	if chr.ignoreCase {
 		cur = unicode.ToLower(cur)
 	}


### PR DESCRIPTION
With the flag `-optimize-basic-latin` set, the parser generates
a lookup table for the Unicode Basic Latin characters for each
character class matcher, which speeds up the parsing for data,
which consists mainly of characters from this range.