### PR TITLE
Statistics for ordered choice expressions

### DIFF
--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2198,6 +2198,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
+	}
+}
+
 // Debug creates an Option to set the debug flag to b. When set to true,
 // debugging information is printed to stdout while parsing.
 //
@@ -2447,6 +2460,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -2458,7 +2475,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -2480,6 +2497,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -2511,15 +2542,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -2745,8 +2771,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -2802,8 +2826,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -2977,25 +3001,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -3003,16 +3023,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2458,6 +2458,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -2516,6 +2517,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -2741,6 +2745,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -2971,19 +2977,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2200,14 +2200,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -2499,6 +2517,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -2510,6 +2530,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -2546,6 +2574,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -3001,8 +3031,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -3013,7 +3041,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -37,14 +37,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 // ==template== {{ if not .Optimize }}
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -338,6 +356,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -349,6 +369,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -387,6 +415,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -887,8 +917,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 // ==template== {{ if not .Optimize }}
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -899,7 +927,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -297,6 +297,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -357,6 +358,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -592,6 +596,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -855,6 +861,27 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	// ==template== {{ if not .Optimize }}
 	if p.debug {
@@ -862,14 +889,16 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	}
 
 	// {{ end }} ==template==
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -35,6 +35,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // ==template== {{ if not .Optimize }}
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
+	}
+}
+
 // Debug creates an Option to set the debug flag to b. When set to true,
 // debugging information is printed to stdout while parsing.
 //
@@ -286,6 +299,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -297,7 +314,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -319,6 +336,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -352,15 +383,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -596,8 +622,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -660,8 +684,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 
 	// {{ end }} ==template==
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -861,26 +885,26 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+// ==template== {{ if not .Optimize }}
+
+const choiceNoMatch = -1
+
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
+	}
+	m[alt]++
 }
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
-	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
-	}
-
-	return buffer.String()
-}
+// {{ end }} ==template==
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	// ==template== {{ if not .Optimize }}
@@ -889,16 +913,23 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	}
 
 	// {{ end }} ==template==
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			// ==template== {{ if not .Optimize }}
+			p.incChoiceAltCnt(ch, altI)
+			// {{ end }} ==template==
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	// ==template== {{ if not .Optimize }}
+	p.incChoiceAltCnt(ch, choiceNoMatch)
+	// {{ end }} ==template==
 	return nil, false
 }
 

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -50,6 +51,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // ==template== {{ if not .Optimize }}
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
+	}
+}
+
 // Debug creates an Option to set the debug flag to b. When set to true,
 // debugging information is printed to stdout while parsing.
 //
@@ -301,6 +315,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -312,7 +330,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -334,6 +352,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -367,15 +399,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -611,8 +638,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -675,8 +700,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 
 	// {{ end }} ==template==
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -876,26 +901,26 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+// ==template== {{ if not .Optimize }}
+
+const choiceNoMatch = -1
+
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
+	}
+	m[alt]++
 }
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
-	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
-	}
-
-	return buffer.String()
-}
+// {{ end }} ==template==
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	// ==template== {{ if not .Optimize }}
@@ -904,16 +929,23 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	}
 
 	// {{ end }} ==template==
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			// ==template== {{ if not .Optimize }}
+			p.incChoiceAltCnt(ch, altI)
+			// {{ end }} ==template==
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	// ==template== {{ if not .Optimize }}
+	p.incChoiceAltCnt(ch, choiceNoMatch)
+	// {{ end }} ==template==
 	return nil, false
 }
 

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -53,14 +53,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 // ==template== {{ if not .Optimize }}
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for the "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -354,6 +372,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -365,6 +385,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -403,6 +431,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -903,8 +933,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 
 // ==template== {{ if not .Optimize }}
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -915,7 +943,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -312,6 +312,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -372,6 +373,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -607,6 +611,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -870,6 +876,27 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	// ==template== {{ if not .Optimize }}
 	if p.debug {
@@ -877,14 +904,16 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	}
 
 	// {{ end }} ==template==
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/doc.go
+++ b/doc.go
@@ -64,8 +64,8 @@ The following options can be specified:
 	more optimizations have applied). This process takes some time, depending on the
 	optimization potential of the grammar.
 
-	-optimize-parser : boolean, if set, the options Debug and Memoize are removed
-	from the resulting parser. This saves a few cpu cycles, when using the
+	-optimize-parser : boolean, if set, the options Debug, Memoize and Statistics are
+	removed	from the resulting parser. This saves a few cpu cycles, when using the
 	generated parser (default: false).
 
 	-x : boolean, if set, do not build the parser, just parse the input grammar
@@ -336,6 +336,7 @@ as a package with public functions to parse input text. The exported API is:
 	- MaxExpressions(uint64) Option
 	- Memoize(bool) Option
 	- Recover(bool) Option
+	- Statistics(*Stats) Option
 
 See the godoc page of the generated parser for the test/predicates grammar
 for an example documentation page of the exported API:

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -736,6 +736,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -794,6 +795,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -1019,6 +1023,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1249,19 +1255,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -478,14 +478,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -777,6 +795,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -788,6 +808,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -824,6 +852,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -1279,8 +1309,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -1291,7 +1319,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -476,6 +476,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
+	}
+}
+
 // Debug creates an Option to set the debug flag to b. When set to true,
 // debugging information is printed to stdout while parsing.
 //
@@ -725,6 +738,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -736,7 +753,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -758,6 +775,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -789,15 +820,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -1023,8 +1049,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1080,8 +1104,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -1255,25 +1279,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -1281,16 +1301,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/examples/calculator/calculator_test.go
+++ b/examples/calculator/calculator_test.go
@@ -135,8 +135,8 @@ func TestMemoization(t *testing.T) {
 	if goti != want {
 		t.Errorf("want %d, got %d", want, goti)
 	}
-	if p.exprCnt != 415 {
-		t.Errorf("with Memoize=false, want %d expressions evaluated, got %d", 415, p.exprCnt)
+	if p.ExprCnt != 415 {
+		t.Errorf("with Memoize=false, want %d expressions evaluated, got %d", 415, p.ExprCnt)
 	}
 
 	p = newParser("", []byte(in), Memoize(true))
@@ -148,8 +148,8 @@ func TestMemoization(t *testing.T) {
 	if goti != want {
 		t.Errorf("want %d, got %d", want, goti)
 	}
-	if p.exprCnt != 389 {
-		t.Errorf("with Memoize=true, want %d expressions evaluated, got %d", 389, p.exprCnt)
+	if p.ExprCnt != 389 {
+		t.Errorf("with Memoize=true, want %d expressions evaluated, got %d", 389, p.ExprCnt)
 	}
 }
 

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -772,14 +772,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -1071,6 +1089,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -1082,6 +1102,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -1118,6 +1146,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -1573,8 +1603,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -1585,7 +1613,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -770,6 +770,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
+	}
+}
+
 // Debug creates an Option to set the debug flag to b. When set to true,
 // debugging information is printed to stdout while parsing.
 //
@@ -1019,6 +1032,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -1030,7 +1047,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -1052,6 +1069,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -1083,15 +1114,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -1317,8 +1343,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1374,8 +1398,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -1549,25 +1573,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -1575,16 +1595,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -1030,6 +1030,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -1088,6 +1089,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -1313,6 +1317,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1543,19 +1549,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/examples/json/json_test.go
+++ b/examples/json/json_test.go
@@ -76,6 +76,62 @@ func testJSONFiles(t *testing.T) []string {
 	return files
 }
 
+func TestChoiceAltStatistics(t *testing.T) {
+	cases := []struct {
+		json          string
+		expectedStats map[string]map[string]int
+	}{
+		{
+			json: `{}`,
+			expectedStats: map[string]map[string]int{
+				"Bool 92:8": map[string]int{
+					"no match": 1,
+				},
+				"Integer 68:11": map[string]int{
+					"no match": 1,
+				},
+				"Value 29:15": map[string]int{
+					"1":        1,
+					"no match": 1,
+				},
+			},
+		},
+		{
+			json: `{ "string": "string", "number": 123 }`,
+			expectedStats: map[string]map[string]int{
+				"Integer 68:11": map[string]int{
+					"2":        1,
+					"no match": 2,
+				},
+				"Bool 92:8": map[string]int{
+					"no match": 1,
+				},
+				"String 72:16": map[string]int{
+					"1":        18,
+					"no match": 3,
+				},
+				"Value 29:15": map[string]int{
+					"1":        1,
+					"3":        1,
+					"4":        1,
+					"no match": 1,
+				},
+			},
+		},
+	}
+
+	for _, test := range cases {
+		stats := Stats{}
+		_, err := Parse("TestStatistics", []byte(test.json), Statistics(&stats))
+		if err != nil {
+			t.Fatalf("Expected to parse %s without error, got: %v", test.json, err)
+		}
+		if !reflect.DeepEqual(test.expectedStats, stats.ChoiceAltCnt) {
+			t.Fatalf("Expected stats to equal %#v, got %#v", test.expectedStats, stats.ChoiceAltCnt)
+		}
+	}
+}
+
 func BenchmarkPigeonJSONNoMemo(b *testing.B) {
 	d, err := ioutil.ReadFile("testdata/github-octokit-repos.json")
 	if err != nil {

--- a/examples/json/json_test.go
+++ b/examples/json/json_test.go
@@ -122,7 +122,7 @@ func TestChoiceAltStatistics(t *testing.T) {
 
 	for _, test := range cases {
 		stats := Stats{}
-		_, err := Parse("TestStatistics", []byte(test.json), Statistics(&stats))
+		_, err := Parse("TestStatistics", []byte(test.json), Statistics(&stats, "no match"))
 		if err != nil {
 			t.Fatalf("Expected to parse %s without error, got: %v", test.json, err)
 		}

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -943,14 +943,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -1242,6 +1260,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -1253,6 +1273,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -1289,6 +1317,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -1744,8 +1774,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -1756,7 +1784,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -941,6 +941,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
+	}
+}
+
 // Debug creates an Option to set the debug flag to b. When set to true,
 // debugging information is printed to stdout while parsing.
 //
@@ -1190,6 +1203,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -1201,7 +1218,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -1223,6 +1240,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -1254,15 +1285,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -1488,8 +1514,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1545,8 +1569,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -1720,25 +1744,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -1746,16 +1766,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -1201,6 +1201,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -1259,6 +1260,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -1484,6 +1488,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1714,19 +1720,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -1000,6 +1000,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -1011,7 +1015,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -1033,6 +1037,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -1058,15 +1076,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -1242,8 +1255,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1269,8 +1280,8 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -1428,38 +1439,18 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
-
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
-	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
-	}
-
-	return buffer.String()
-}
-
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -1039,6 +1039,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -1050,6 +1052,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -1080,6 +1090,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -1011,6 +1011,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -1063,6 +1064,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -1238,6 +1242,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1422,15 +1428,38 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/pigeon.go
+++ b/pigeon.go
@@ -3125,6 +3125,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -3183,6 +3184,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -3408,6 +3412,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -3638,19 +3644,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/pigeon.go
+++ b/pigeon.go
@@ -2865,6 +2865,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
+	}
+}
+
 // Debug creates an Option to set the debug flag to b. When set to true,
 // debugging information is printed to stdout while parsing.
 //
@@ -3114,6 +3127,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -3125,7 +3142,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -3147,6 +3164,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -3178,15 +3209,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -3412,8 +3438,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -3469,8 +3493,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -3644,25 +3668,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -3670,16 +3690,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/pigeon.go
+++ b/pigeon.go
@@ -2867,14 +2867,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -3166,6 +3184,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -3177,6 +3197,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -3213,6 +3241,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -3668,8 +3698,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -3680,7 +3708,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/targeted_test.go
+++ b/targeted_test.go
@@ -764,6 +764,10 @@ func TestParseChoiceExpr(t *testing.T) {
 	for _, tc := range cases {
 		p := newParser("", []byte(tc.in))
 
+		// add dummy rule to rule stack of parser
+		r := rule{name: "dummy"}
+		p.rstack = append(p.rstack, &r)
+
 		// advance to the first rune
 		p.read()
 

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -204,6 +205,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 		oldMaxExprCnt := p.maxExprCnt
 		p.maxExprCnt = maxExprCnt
 		return MaxExpressions(oldMaxExprCnt)
+	}
+}
+
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
 	}
 }
 
@@ -456,6 +470,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -467,7 +485,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -489,6 +507,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -520,15 +552,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -754,8 +781,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -811,8 +836,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -986,25 +1011,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -1012,16 +1033,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -467,6 +467,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -525,6 +526,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -750,6 +754,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -980,19 +986,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -210,14 +210,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -509,6 +527,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -520,6 +540,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -556,6 +584,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -1011,8 +1041,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -1023,7 +1051,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -608,14 +608,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -907,6 +925,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -918,6 +938,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -954,6 +982,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -1409,8 +1439,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -1421,7 +1449,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -605,6 +606,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
+	}
+}
+
 // Debug creates an Option to set the debug flag to b. When set to true,
 // debugging information is printed to stdout while parsing.
 //
@@ -854,6 +868,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -865,7 +883,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -887,6 +905,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -918,15 +950,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -1152,8 +1179,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1209,8 +1234,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -1384,25 +1409,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -1410,16 +1431,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -865,6 +865,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -923,6 +924,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -1148,6 +1152,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1378,19 +1384,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -477,6 +477,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -535,6 +536,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -760,6 +764,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -990,19 +996,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -220,14 +220,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -519,6 +537,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -530,6 +550,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -566,6 +594,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -1021,8 +1051,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -1033,7 +1061,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -685,6 +685,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -743,6 +744,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -968,6 +972,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1198,19 +1204,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -428,14 +428,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -727,6 +745,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -738,6 +758,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -774,6 +802,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -1229,8 +1259,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -1241,7 +1269,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -425,6 +426,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
+	}
+}
+
 // Debug creates an Option to set the debug flag to b. When set to true,
 // debugging information is printed to stdout while parsing.
 //
@@ -674,6 +688,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -685,7 +703,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -707,6 +725,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -738,15 +770,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -972,8 +999,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1029,8 +1054,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -1204,25 +1229,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -1230,16 +1251,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -398,6 +398,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -456,6 +457,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -681,6 +685,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -911,19 +917,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -141,14 +141,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -440,6 +458,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -451,6 +471,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -487,6 +515,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -942,8 +972,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -954,7 +982,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -135,6 +136,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 		oldMaxExprCnt := p.maxExprCnt
 		p.maxExprCnt = maxExprCnt
 		return MaxExpressions(oldMaxExprCnt)
+	}
+}
+
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
 	}
 }
 
@@ -387,6 +401,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -398,7 +416,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -420,6 +438,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -451,15 +483,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -685,8 +712,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -742,8 +767,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -917,25 +942,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -943,16 +964,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/test/issue_12/issue_12.go
+++ b/test/issue_12/issue_12.go
@@ -485,6 +485,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -543,6 +544,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -768,6 +772,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -998,19 +1004,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/test/issue_12/issue_12.go
+++ b/test/issue_12/issue_12.go
@@ -228,14 +228,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -527,6 +545,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -538,6 +558,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -574,6 +602,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -1029,8 +1059,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -1041,7 +1069,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/test/issue_12/issue_12.go
+++ b/test/issue_12/issue_12.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -222,6 +223,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 		oldMaxExprCnt := p.maxExprCnt
 		p.maxExprCnt = maxExprCnt
 		return MaxExpressions(oldMaxExprCnt)
+	}
+}
+
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
 	}
 }
 
@@ -474,6 +488,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -485,7 +503,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -507,6 +525,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -538,15 +570,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -772,8 +799,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -829,8 +854,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -1004,25 +1029,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -1030,16 +1051,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -407,6 +407,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -465,6 +466,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -690,6 +694,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -920,19 +926,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -150,14 +150,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -449,6 +467,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -460,6 +480,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -496,6 +524,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -951,8 +981,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -963,7 +991,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -144,6 +145,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 		oldMaxExprCnt := p.maxExprCnt
 		p.maxExprCnt = maxExprCnt
 		return MaxExpressions(oldMaxExprCnt)
+	}
+}
+
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
 	}
 }
 
@@ -396,6 +410,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -407,7 +425,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -429,6 +447,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -460,15 +492,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -694,8 +721,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -751,8 +776,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -926,25 +951,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -952,16 +973,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -485,6 +485,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -543,6 +544,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -768,6 +772,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -998,19 +1004,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -228,14 +228,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -527,6 +545,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -538,6 +558,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -574,6 +602,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -1029,8 +1059,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -1041,7 +1069,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -222,6 +223,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 		oldMaxExprCnt := p.maxExprCnt
 		p.maxExprCnt = maxExprCnt
 		return MaxExpressions(oldMaxExprCnt)
+	}
+}
+
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
 	}
 }
 
@@ -474,6 +488,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -485,7 +503,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -507,6 +525,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -538,15 +570,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -772,8 +799,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -829,8 +854,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -1004,25 +1029,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -1030,16 +1051,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -57,6 +58,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 		oldMaxExprCnt := p.maxExprCnt
 		p.maxExprCnt = maxExprCnt
 		return MaxExpressions(oldMaxExprCnt)
+	}
+}
+
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
 	}
 }
 
@@ -309,6 +323,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -320,7 +338,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -342,6 +360,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -373,15 +405,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -607,8 +634,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -664,8 +689,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -839,25 +864,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -865,16 +886,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -276,14 +276,32 @@ func MaxExpressions(maxExprCnt uint64) Option {
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
-func Statistics(stats *Stats) Option {
+// Also the key for "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
 	return func(p *parser) Option {
-		old := p.Stats
+		oldStats := p.Stats
 		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
 		if p.Stats.ChoiceAltCnt == nil {
 			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
 		}
-		return Statistics(old)
+		return Statistics(oldStats, oldChoiceNoMatch)
 	}
 }
 
@@ -575,6 +593,8 @@ type resultTuple struct {
 	end savepoint
 }
 
+const choiceNoMatch = -1
+
 // Stats stores some statistics, gathered during parsing
 type Stats struct {
 	// ExprCnt counts the number of expressions processed during parsing
@@ -586,6 +606,14 @@ type Stats struct {
 	// which alternative is used how may times.
 	// These numbers allow to optimize the order of the ordered choice expression
 	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
 	ChoiceAltCnt map[string]map[string]int
 }
 
@@ -622,6 +650,8 @@ type parser struct {
 	maxExprCnt uint64
 
 	*Stats
+
+	choiceNoMatch string
 }
 
 // push a variable set on the vstack.
@@ -1077,8 +1107,6 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-const choiceNoMatch = -1
-
 func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
 	m := p.ChoiceAltCnt[choiceIdent]
@@ -1089,7 +1117,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	// We increment altI by 1, so the keys do not start at 0
 	alt := strconv.Itoa(altI + 1)
 	if altI == choiceNoMatch {
-		alt = "no match"
+		alt = p.choiceNoMatch
 	}
 	m[alt]++
 }

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -273,6 +274,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+func Statistics(stats *Stats) Option {
+	return func(p *parser) Option {
+		old := p.Stats
+		p.Stats = stats
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(old)
+	}
+}
+
 // Debug creates an Option to set the debug flag to b. When set to true,
 // debugging information is printed to stdout while parsing.
 //
@@ -522,6 +536,10 @@ func (p *parserError) Error() string {
 
 // newParser creates a parser with the specified input source and options.
 func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
 	p := &parser{
 		filename: filename,
 		errs:     new(errList),
@@ -533,7 +551,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
-		choiceAltCnt:    make(map[string]int),
+		Stats:           &stats,
 	}
 	p.setOptions(opts)
 
@@ -555,6 +573,20 @@ type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
+}
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	ChoiceAltCnt map[string]map[string]int
 }
 
 type parser struct {
@@ -586,15 +618,10 @@ type parser struct {
 	maxFailExpected       []string
 	maxFailInvertExpected bool
 
-	// stats and used for stopping the parser
-	// after a maximum number of expressions are parsed
-	exprCnt uint64
-
 	// max number of expressions to be parsed
 	maxExprCnt uint64
 
-	// stats for alternatives of the ordred choice operators
-	choiceAltCnt map[string]int
+	*Stats
 }
 
 // push a variable set on the vstack.
@@ -820,8 +847,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
-	// TODO: return stats as JSON
-	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -877,8 +902,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
-	p.exprCnt++
-	if p.exprCnt > p.maxExprCnt {
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
@@ -1052,25 +1077,21 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
-	if alternative == -1 {
-		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
-	}
-	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
-}
+const choiceNoMatch = -1
 
-func (p *parser) printChoiceAltCnt() string {
-	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
-	for k := range p.choiceAltCnt {
-		choiceAltCnt = append(choiceAltCnt, k)
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
 	}
-	sort.Strings(choiceAltCnt)
-	var buffer bytes.Buffer
-	for _, k := range choiceAltCnt {
-		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = "no match"
 	}
-
-	return buffer.String()
+	m[alt]++
 }
 
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
@@ -1078,16 +1099,19 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for i, alt := range ch.alternatives {
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
 	}
-	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -533,6 +533,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		},
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
+		choiceAltCnt:    make(map[string]int),
 	}
 	p.setOptions(opts)
 
@@ -591,6 +592,9 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+
+	// stats for alternatives of the ordred choice operators
+	choiceAltCnt map[string]int
 }
 
 // push a variable set on the vstack.
@@ -816,6 +820,8 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 
 		return nil, p.errs.err()
 	}
+	// TODO: return stats as JSON
+	fmt.Fprintf(os.Stderr, "%s\n", p.printChoiceAltCnt())
 	return val, p.errs.err()
 }
 
@@ -1046,19 +1052,42 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func choiceIdent(r *rule, ch *choiceExpr, alternative int) string {
+	if alternative == -1 {
+		return fmt.Sprintf("%s %d:%d:f", r.name, ch.pos.line, ch.pos.col)
+	}
+	return fmt.Sprintf("%s %d:%d:%d", r.name, ch.pos.line, ch.pos.col, alternative)
+}
+
+func (p *parser) printChoiceAltCnt() string {
+	choiceAltCnt := make([]string, 0, len(p.choiceAltCnt))
+	for k := range p.choiceAltCnt {
+		choiceAltCnt = append(choiceAltCnt, k)
+	}
+	sort.Strings(choiceAltCnt)
+	var buffer bytes.Buffer
+	for _, k := range choiceAltCnt {
+		buffer.WriteString(fmt.Sprintf("%s: %d\n", k, p.choiceAltCnt[k]))
+	}
+
+	return buffer.String()
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
 
-	for _, alt := range ch.alternatives {
+	for i, alt := range ch.alternatives {
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, i+1)]++
 			return val, ok
 		}
 	}
+	p.choiceAltCnt[choiceIdent(p.rstack[len(p.rstack)-1], ch, -1)]++
 	return nil, false
 }
 


### PR DESCRIPTION
This PR implements a statistic feature for the ordered choice expressions, which helps the author of a PEG grammar to optimize the parsing by order the alternatives in an ordered choice expression by their frequency  (most used alternatives first).