### PR TITLE
implement the alternate entrypoints feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ $(TEST_DIR)/thrownrecover/thrownrecover.go: $(TEST_DIR)/thrownrecover/thrownreco
 	$(BINDIR)/pigeon $< > $@
 
 $(TEST_DIR)/alternate_entrypoint/altentry.go: $(TEST_DIR)/alternate_entrypoint/altentry.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon -optimize-grammar -alternate-entrypoints Entry2 $< > $@
+	$(BINDIR)/pigeon -optimize-grammar -alternate-entrypoints Entry2,Entry3,C $< > $@
 
 lint:
 	golint ./...

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,9 @@ $(TEST_DIR)/labeled_failures/labeled_failures.go: $(TEST_DIR)/labeled_failures/l
 $(TEST_DIR)/thrownrecover/thrownrecover.go: $(TEST_DIR)/thrownrecover/thrownrecover.peg $(BINDIR)/pigeon
 	$(BINDIR)/pigeon $< > $@
 
+$(TEST_DIR)/alternate_entrypoint/altentry.go: $(TEST_DIR)/alternate_entrypoint/altentry.peg $(BINDIR)/pigeon
+	$(BINDIR)/pigeon -optimize-grammar -alternate-entrypoints Entry2 $< > $@
+
 lint:
 	golint ./...
 	go vet ./...

--- a/ast/ast_optimize.go
+++ b/ast/ast_optimize.go
@@ -8,7 +8,7 @@ import (
 
 type grammarOptimizer struct {
 	rule            string
-	firstRule       string
+	protectedRules  map[string]struct{}
 	rules           map[string]*Rule
 	ruleUsesRules   map[string]map[string]struct{}
 	ruleUsedByRules map[string]map[string]struct{}
@@ -16,8 +16,14 @@ type grammarOptimizer struct {
 	optimized       bool
 }
 
-func newGrammarOptimizer() *grammarOptimizer {
+func newGrammarOptimizer(protectedRules []string) *grammarOptimizer {
+	pr := make(map[string]struct{}, len(protectedRules))
+	for _, nm := range protectedRules {
+		pr[nm] = struct{}{}
+	}
+
 	r := grammarOptimizer{
+		protectedRules:  pr,
 		rules:           make(map[string]*Rule),
 		ruleUsesRules:   make(map[string]map[string]struct{}),
 		ruleUsedByRules: make(map[string]map[string]struct{}),
@@ -39,9 +45,6 @@ func (r *grammarOptimizer) Visit(expr Expression) Visitor {
 func (r *grammarOptimizer) init(expr Expression) Visitor {
 	switch expr := expr.(type) {
 	case *Rule:
-		if r.firstRule == "" {
-			r.firstRule = expr.Name.Val
-		}
 		// Keep track of current rule, which is processed
 		r.rule = expr.Name.Val
 		r.rules[expr.Name.Val] = expr
@@ -146,7 +149,9 @@ func (r *grammarOptimizer) optimize(expr0 Expression) Visitor {
 		for i := 0; i < len(expr.Rules); i++ {
 			rule := expr.Rules[i]
 			// Remove Rule, if it is no longer used by any other Rule and it is not the first Rule.
-			if _, ok := r.ruleUsedByRules[rule.Name.Val]; !ok && rule.Name.Val != r.firstRule {
+			_, used := r.ruleUsedByRules[rule.Name.Val]
+			_, protected := r.protectedRules[rule.Name.Val]
+			if !used && !protected {
 				expr.Rules = append(expr.Rules[:i], expr.Rules[i+1:]...)
 				r.optimized = true
 				continue
@@ -423,8 +428,13 @@ func escapeRune(r rune) string {
 // * resolve nested sequences expression
 // * resolve sequence expressions with only one element
 // * combine character class matcher and literal matcher, where possible
-func Optimize(g *Grammar) {
-	r := newGrammarOptimizer()
+func Optimize(g *Grammar, alternateEntrypoints ...string) {
+	entrypoints := alternateEntrypoints
+	if len(g.Rules) > 0 {
+		entrypoints = append(entrypoints, g.Rules[0].Name.Val)
+	}
+
+	r := newGrammarOptimizer(entrypoints)
 	Walk(r, g)
 
 	r.visitor = r.optimize

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2198,7 +2198,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -2586,7 +2598,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -2812,10 +2825,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2203,15 +2203,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -2524,6 +2528,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -2829,18 +2835,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2198,6 +2198,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -2584,6 +2586,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -2809,6 +2812,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2172,6 +2172,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -2829,6 +2833,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -39,15 +39,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -363,6 +367,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -680,18 +686,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -8,6 +8,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -680,6 +684,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -34,6 +34,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // ==template== {{ if not .Optimize }}
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -425,6 +427,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -660,6 +663,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -34,7 +34,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // ==template== {{ if not .Optimize }}
 // Statistics adds a user provided Stats struct to the parser to allow
@@ -427,7 +439,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -663,10 +676,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -55,15 +55,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -379,6 +383,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -696,18 +702,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -50,6 +50,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // ==template== {{ if not .Optimize }}
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -441,6 +443,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add `entrypoint string` field, use default if empty
 
 	*Stats
 
@@ -676,6 +679,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -443,7 +443,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add `entrypoint string` field, use default if empty
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -50,7 +50,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // ==template== {{ if not .Optimize }}
 // Statistics adds a user provided Stats struct to the parser to allow
@@ -443,7 +455,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -679,10 +692,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -24,6 +24,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -696,6 +700,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/doc.go
+++ b/doc.go
@@ -75,6 +75,12 @@ The following options can be specified:
 	code blocks. Non-initializer code blocks in the grammar end up as methods on the
 	*current type, and this option sets the name of the receiver (default: c).
 
+	-alternate-entrypoints=RULE[,RULE...] : string, comma-separated list of rule names
+	that may be used as alternate entrypoints for the parser, in addition to the
+	default entrypoint (the first rule in the grammar) (default: none).
+	Such entrypoints can be specified in the call to Parse by passing an
+	Entrypoint option that specifies the alternate rule name to use.
+
 If the code blocks in the grammar (see below, section "Code block") are golint-
 and go vet-compliant, then the resulting generated code will also be golint-
 and go vet-compliant.
@@ -372,6 +378,7 @@ as a package with public functions to parse input text. The exported API is:
 	- ParseFile(string, ...Option) (interface{}, error)
 	- ParseReader(string, io.Reader, ...Option) (interface{}, error)
 	- Debug(bool) Option
+	- Entrypoint(string) Option
 	- GlobalStore(string, interface{}) Option
 	- MaxExpressions(uint64) Option
 	- Memoize(bool) Option

--- a/doc.go
+++ b/doc.go
@@ -79,7 +79,9 @@ The following options can be specified:
 	that may be used as alternate entrypoints for the parser, in addition to the
 	default entrypoint (the first rule in the grammar) (default: none).
 	Such entrypoints can be specified in the call to Parse by passing an
-	Entrypoint option that specifies the alternate rule name to use.
+	Entrypoint option that specifies the alternate rule name to use. This is only
+	necessary if the -optimize-parser flag is set, as some rules may be optimized
+	out of the resulting parser.
 
 If the code blocks in the grammar (see below, section "Code block") are golint-
 and go vet-compliant, then the resulting generated code will also be golint-

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -450,6 +450,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -1107,6 +1111,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -476,6 +476,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -862,6 +864,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -1087,6 +1090,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -476,7 +476,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -864,7 +876,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -1090,10 +1103,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -481,15 +481,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -802,6 +806,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -1107,18 +1113,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -770,7 +770,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -1158,7 +1170,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -1384,10 +1397,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -770,6 +770,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -1156,6 +1158,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -1381,6 +1384,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -775,15 +775,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -1096,6 +1100,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -1401,18 +1407,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -744,6 +744,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -1401,6 +1405,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -941,7 +941,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -1329,7 +1341,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -1555,10 +1568,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -941,6 +941,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -1327,6 +1329,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -1552,6 +1555,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -915,6 +915,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -1572,6 +1576,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -946,15 +946,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -1267,6 +1271,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -1572,18 +1578,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -751,6 +751,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -1295,6 +1299,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -777,6 +777,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -1100,6 +1102,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -1275,6 +1278,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -782,15 +782,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -1046,6 +1050,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -1295,18 +1301,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -777,7 +777,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
@@ -1102,7 +1114,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -1278,10 +1291,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 		optimizeParserFlag     = fs.Bool("optimize-parser", false, "generate optimized parser without Debug and Memoize options")
 		recvrNmFlag            = fs.String("receiver-name", "c", "receiver name for the generated methods")
 		noBuildFlag            = fs.Bool("x", false, "do not build, only parse")
+		// TODO(mna): support --alternate-entrypoints flag, comma-separated list of rule names
 	)
 
 	fs.Usage = usage
@@ -80,7 +81,9 @@ func main() {
 	}
 
 	if !*noBuildFlag {
+		// TODO(mna): validate that all alternate entrypoints are valid rule names
 		if *optimizeGrammar {
+			// TODO(mna): pass the alternate entrypoints as rules to keep in the grammar
 			ast.Optimize(g.(*ast.Grammar))
 		}
 

--- a/main.go
+++ b/main.go
@@ -83,21 +83,19 @@ func main() {
 	// validate alternate entrypoints
 	entrypoints := strings.Split(*altEntrypointsFlag, ",")
 	grammar := g.(*ast.Grammar)
+
+	// set of valid rule names
+	rules := make(map[string]struct{}, len(grammar.Rules))
+	for _, rule := range grammar.Rules {
+		rules[rule.Name.Val] = struct{}{}
+	}
+
 	for _, entrypoint := range entrypoints {
 		if entrypoint == "" {
 			continue
 		}
 
-		found := false
-		// TODO(mna): build set of rule names
-		for _, rule := range grammar.Rules {
-			if rule.Name.Val == entrypoint {
-				found = true
-				break
-			}
-		}
-
-		if !found {
+		if _, ok := rules[entrypoint]; !ok {
 			fmt.Fprintf(os.Stderr, "argument error:\nunknown rule name %s used as alternate entrypoint\n", entrypoint)
 			exit(9)
 		}

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 		}
 
 		found := false
-		// TODO: build set of rule names
+		// TODO(mna): build set of rule names
 		for _, rule := range grammar.Rules {
 			if rule.Name.Val == entrypoint {
 				found = true
@@ -105,8 +105,7 @@ func main() {
 
 	if !*noBuildFlag {
 		if *optimizeGrammar {
-			// TODO(mna): pass the alternate entrypoints as rules to keep in the grammar
-			ast.Optimize(grammar)
+			ast.Optimize(grammar, entrypoints...)
 		}
 
 		// generate parser

--- a/main.go
+++ b/main.go
@@ -186,10 +186,10 @@ the generated code is written to this file instead.
 		for the grammar's code blocks. Defaults to "c".
 	-x
 		do not generate the parser, only parse the grammar.
-  -alternate-entrypoints
-    comma-separated list of rule names that may be used as alternate
-    entrypoints for the parser, in addition to the first rule in the
-    grammar.
+ 	-alternate-entrypoints RULE[,RULE...]
+		comma-separated list of rule names that may be used as alternate
+		entrypoints for the parser, in addition to the first rule in the
+		grammar.
 
 See https://godoc.org/github.com/mna/pigeon for more information.
 `

--- a/pigeon.go
+++ b/pigeon.go
@@ -3094,6 +3094,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -3751,6 +3755,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/pigeon.go
+++ b/pigeon.go
@@ -3120,7 +3120,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -3508,7 +3520,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -3734,10 +3747,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/pigeon.go
+++ b/pigeon.go
@@ -3120,6 +3120,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -3506,6 +3508,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -3731,6 +3734,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/pigeon.go
+++ b/pigeon.go
@@ -3125,15 +3125,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -3446,6 +3450,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -3751,18 +3757,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -114,6 +114,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -773,6 +777,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -1,0 +1,1259 @@
+package alternate_entrypoint
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+var g = &grammar{
+	rules: []*rule{
+		{
+			name: "Entry1",
+			pos:  position{line: 5, col: 1, offset: 36},
+			expr: &actionExpr{
+				pos: position{line: 5, col: 11, offset: 46},
+				run: (*parser).callonEntry11,
+				expr: &seqExpr{
+					pos: position{line: 5, col: 11, offset: 46},
+					exprs: []interface{}{
+						&oneOrMoreExpr{
+							pos: position{line: 13, col: 6, offset: 129},
+							expr: &litMatcher{
+								pos:        position{line: 13, col: 6, offset: 129},
+								val:        "a",
+								ignoreCase: false,
+							},
+						},
+						&oneOrMoreExpr{
+							pos: position{line: 15, col: 6, offset: 149},
+							expr: &litMatcher{
+								pos:        position{line: 15, col: 6, offset: 149},
+								val:        "c",
+								ignoreCase: false,
+							},
+						},
+						&notExpr{
+							pos: position{line: 17, col: 7, offset: 163},
+							expr: &anyMatcher{
+								line: 17, col: 8, offset: 164,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Entry2",
+			pos:  position{line: 9, col: 1, offset: 80},
+			expr: &actionExpr{
+				pos: position{line: 9, col: 11, offset: 90},
+				run: (*parser).callonEntry21,
+				expr: &seqExpr{
+					pos: position{line: 9, col: 11, offset: 90},
+					exprs: []interface{}{
+						&oneOrMoreExpr{
+							pos: position{line: 14, col: 6, offset: 139},
+							expr: &litMatcher{
+								pos:        position{line: 14, col: 6, offset: 139},
+								val:        "b",
+								ignoreCase: false,
+							},
+						},
+						&oneOrMoreExpr{
+							pos: position{line: 15, col: 6, offset: 149},
+							expr: &litMatcher{
+								pos:        position{line: 15, col: 6, offset: 149},
+								val:        "c",
+								ignoreCase: false,
+							},
+						},
+						&notExpr{
+							pos: position{line: 17, col: 7, offset: 163},
+							expr: &anyMatcher{
+								line: 17, col: 8, offset: 164,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func (c *current) onEntry11() (interface{}, error) {
+	return c.text, nil
+}
+
+func (p *parser) callonEntry11() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onEntry11()
+}
+
+func (c *current) onEntry21() (interface{}, error) {
+	return c.text, nil
+}
+
+func (p *parser) callonEntry21() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onEntry21()
+}
+
+var (
+	// errNoRule is returned when the grammar to parse has no rule.
+	errNoRule = errors.New("grammar has no rule")
+
+	// errInvalidEncoding is returned when the source is not properly
+	// utf8-encoded.
+	errInvalidEncoding = errors.New("invalid encoding")
+
+	// errMaxExprCnt is used to signal that the maximum number of
+	// expressions have been parsed.
+	errMaxExprCnt = errors.New("max number of expresssions parsed")
+)
+
+// Option is a function that can set an option on the parser. It returns
+// the previous setting as an Option.
+type Option func(*parser) Option
+
+// MaxExpressions creates an Option to stop parsing after the provided
+// number of expressions have been parsed, if the value is 0 then the parser will
+// parse for as many steps as needed (possibly an infinite number).
+//
+// The default for maxExprCnt is 0.
+func MaxExpressions(maxExprCnt uint64) Option {
+	return func(p *parser) Option {
+		oldMaxExprCnt := p.maxExprCnt
+		p.maxExprCnt = maxExprCnt
+		return MaxExpressions(oldMaxExprCnt)
+	}
+}
+
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
+
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+// Also the key for the "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
+	return func(p *parser) Option {
+		oldStats := p.Stats
+		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(oldStats, oldChoiceNoMatch)
+	}
+}
+
+// Debug creates an Option to set the debug flag to b. When set to true,
+// debugging information is printed to stdout while parsing.
+//
+// The default is false.
+func Debug(b bool) Option {
+	return func(p *parser) Option {
+		old := p.debug
+		p.debug = b
+		return Debug(old)
+	}
+}
+
+// Memoize creates an Option to set the memoize flag to b. When set to true,
+// the parser will cache all results so each expression is evaluated only
+// once. This guarantees linear parsing time even for pathological cases,
+// at the expense of more memory and slower times for typical cases.
+//
+// The default is false.
+func Memoize(b bool) Option {
+	return func(p *parser) Option {
+		old := p.memoize
+		p.memoize = b
+		return Memoize(old)
+	}
+}
+
+// Recover creates an Option to set the recover flag to b. When set to
+// true, this causes the parser to recover from panics and convert it
+// to an error. Setting it to false can be useful while debugging to
+// access the full stack trace.
+//
+// The default is true.
+func Recover(b bool) Option {
+	return func(p *parser) Option {
+		old := p.recover
+		p.recover = b
+		return Recover(old)
+	}
+}
+
+// GlobalStore creates an Option to set a key to a certain value in
+// the globalStore.
+func GlobalStore(key string, value interface{}) Option {
+	return func(p *parser) Option {
+		old := p.cur.globalStore[key]
+		p.cur.globalStore[key] = value
+		return GlobalStore(key, old)
+	}
+}
+
+// ParseFile parses the file identified by filename.
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			err = closeErr
+		}
+	}()
+	return ParseReader(filename, f, opts...)
+}
+
+// ParseReader parses the data from r using filename as information in the
+// error messages.
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return Parse(filename, b, opts...)
+}
+
+// Parse parses the data from b using filename as information in the
+// error messages.
+func Parse(filename string, b []byte, opts ...Option) (interface{}, error) {
+	return newParser(filename, b, opts...).parse(g)
+}
+
+// position records a position in the text.
+type position struct {
+	line, col, offset int
+}
+
+func (p position) String() string {
+	return fmt.Sprintf("%d:%d [%d]", p.line, p.col, p.offset)
+}
+
+// savepoint stores all state required to go back to this point in the
+// parser.
+type savepoint struct {
+	position
+	rn rune
+	w  int
+}
+
+type current struct {
+	pos  position // start position of the match
+	text []byte   // raw text of the match
+
+	// the globalStore allows the parser to store arbitrary values
+	globalStore map[string]interface{}
+}
+
+// the AST types...
+
+type grammar struct {
+	pos   position
+	rules []*rule
+}
+
+type rule struct {
+	pos         position
+	name        string
+	displayName string
+	expr        interface{}
+}
+
+type choiceExpr struct {
+	pos          position
+	alternatives []interface{}
+}
+
+type actionExpr struct {
+	pos  position
+	expr interface{}
+	run  func(*parser) (interface{}, error)
+}
+
+type recoveryExpr struct {
+	pos          position
+	expr         interface{}
+	recoverExpr  interface{}
+	failureLabel []string
+}
+
+type seqExpr struct {
+	pos   position
+	exprs []interface{}
+}
+
+type throwExpr struct {
+	pos   position
+	label string
+}
+
+type labeledExpr struct {
+	pos   position
+	label string
+	expr  interface{}
+}
+
+type expr struct {
+	pos  position
+	expr interface{}
+}
+
+type andExpr expr
+type notExpr expr
+type zeroOrOneExpr expr
+type zeroOrMoreExpr expr
+type oneOrMoreExpr expr
+
+type ruleRefExpr struct {
+	pos  position
+	name string
+}
+
+type andCodeExpr struct {
+	pos position
+	run func(*parser) (bool, error)
+}
+
+type notCodeExpr struct {
+	pos position
+	run func(*parser) (bool, error)
+}
+
+type litMatcher struct {
+	pos        position
+	val        string
+	ignoreCase bool
+}
+
+type charClassMatcher struct {
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
+}
+
+type anyMatcher position
+
+// errList cumulates the errors found by the parser.
+type errList []error
+
+func (e *errList) add(err error) {
+	*e = append(*e, err)
+}
+
+func (e errList) err() error {
+	if len(e) == 0 {
+		return nil
+	}
+	e.dedupe()
+	return e
+}
+
+func (e *errList) dedupe() {
+	var cleaned []error
+	set := make(map[string]bool)
+	for _, err := range *e {
+		if msg := err.Error(); !set[msg] {
+			set[msg] = true
+			cleaned = append(cleaned, err)
+		}
+	}
+	*e = cleaned
+}
+
+func (e errList) Error() string {
+	switch len(e) {
+	case 0:
+		return ""
+	case 1:
+		return e[0].Error()
+	default:
+		var buf bytes.Buffer
+
+		for i, err := range e {
+			if i > 0 {
+				buf.WriteRune('\n')
+			}
+			buf.WriteString(err.Error())
+		}
+		return buf.String()
+	}
+}
+
+// parserError wraps an error with a prefix indicating the rule in which
+// the error occurred. The original error is stored in the Inner field.
+type parserError struct {
+	Inner    error
+	pos      position
+	prefix   string
+	expected []string
+}
+
+// Error returns the error message.
+func (p *parserError) Error() string {
+	return p.prefix + ": " + p.Inner.Error()
+}
+
+// newParser creates a parser with the specified input source and options.
+func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
+	p := &parser{
+		filename: filename,
+		errs:     new(errList),
+		data:     b,
+		pt:       savepoint{position: position{line: 1}},
+		recover:  true,
+		cur: current{
+			globalStore: make(map[string]interface{}),
+		},
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make([]string, 0, 20),
+		Stats:           &stats,
+	}
+	p.setOptions(opts)
+
+	if p.maxExprCnt == 0 {
+		p.maxExprCnt = math.MaxUint64
+	}
+
+	return p
+}
+
+// setOptions applies the options to the parser.
+func (p *parser) setOptions(opts []Option) {
+	for _, opt := range opts {
+		opt(p)
+	}
+}
+
+type resultTuple struct {
+	v   interface{}
+	b   bool
+	end savepoint
+}
+
+const choiceNoMatch = -1
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
+	ChoiceAltCnt map[string]map[string]int
+}
+
+type parser struct {
+	filename string
+	pt       savepoint
+	cur      current
+
+	data []byte
+	errs *errList
+
+	depth   int
+	recover bool
+	debug   bool
+
+	memoize bool
+	// memoization table for the packrat algorithm:
+	// map[offset in source] map[expression or rule] {value, match}
+	memo map[int]map[interface{}]resultTuple
+
+	// rules table, maps the rule identifier to the rule node
+	rules map[string]*rule
+	// variables stack, map of label to value
+	vstack []map[string]interface{}
+	// rule stack, allows identification of the current rule in errors
+	rstack []*rule
+
+	// parse fail
+	maxFailPos            position
+	maxFailExpected       []string
+	maxFailInvertExpected bool
+
+	// max number of expressions to be parsed
+	maxExprCnt uint64
+	// entrypoint for the parser
+	entrypoint string
+
+	*Stats
+
+	choiceNoMatch string
+	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
+	recoveryStack []map[string]interface{}
+}
+
+// push a variable set on the vstack.
+func (p *parser) pushV() {
+	if cap(p.vstack) == len(p.vstack) {
+		// create new empty slot in the stack
+		p.vstack = append(p.vstack, nil)
+	} else {
+		// slice to 1 more
+		p.vstack = p.vstack[:len(p.vstack)+1]
+	}
+
+	// get the last args set
+	m := p.vstack[len(p.vstack)-1]
+	if m != nil && len(m) == 0 {
+		// empty map, all good
+		return
+	}
+
+	m = make(map[string]interface{})
+	p.vstack[len(p.vstack)-1] = m
+}
+
+// pop a variable set from the vstack.
+func (p *parser) popV() {
+	// if the map is not empty, clear it
+	m := p.vstack[len(p.vstack)-1]
+	if len(m) > 0 {
+		// GC that map
+		p.vstack[len(p.vstack)-1] = nil
+	}
+	p.vstack = p.vstack[:len(p.vstack)-1]
+}
+
+// push a recovery expression with its labels to the recoveryStack
+func (p *parser) pushRecovery(labels []string, expr interface{}) {
+	if cap(p.recoveryStack) == len(p.recoveryStack) {
+		// create new empty slot in the stack
+		p.recoveryStack = append(p.recoveryStack, nil)
+	} else {
+		// slice to 1 more
+		p.recoveryStack = p.recoveryStack[:len(p.recoveryStack)+1]
+	}
+
+	m := make(map[string]interface{}, len(labels))
+	for _, fl := range labels {
+		m[fl] = expr
+	}
+	p.recoveryStack[len(p.recoveryStack)-1] = m
+}
+
+// pop a recovery expression from the recoveryStack
+func (p *parser) popRecovery() {
+	// GC that map
+	p.recoveryStack[len(p.recoveryStack)-1] = nil
+
+	p.recoveryStack = p.recoveryStack[:len(p.recoveryStack)-1]
+}
+
+func (p *parser) print(prefix, s string) string {
+	if !p.debug {
+		return s
+	}
+
+	fmt.Printf("%s %d:%d:%d: %s [%#U]\n",
+		prefix, p.pt.line, p.pt.col, p.pt.offset, s, p.pt.rn)
+	return s
+}
+
+func (p *parser) in(s string) string {
+	p.depth++
+	return p.print(strings.Repeat(" ", p.depth)+">", s)
+}
+
+func (p *parser) out(s string) string {
+	p.depth--
+	return p.print(strings.Repeat(" ", p.depth)+"<", s)
+}
+
+func (p *parser) addErr(err error) {
+	p.addErrAt(err, p.pt.position, []string{})
+}
+
+func (p *parser) addErrAt(err error, pos position, expected []string) {
+	var buf bytes.Buffer
+	if p.filename != "" {
+		buf.WriteString(p.filename)
+	}
+	if buf.Len() > 0 {
+		buf.WriteString(":")
+	}
+	buf.WriteString(fmt.Sprintf("%d:%d (%d)", pos.line, pos.col, pos.offset))
+	if len(p.rstack) > 0 {
+		if buf.Len() > 0 {
+			buf.WriteString(": ")
+		}
+		rule := p.rstack[len(p.rstack)-1]
+		if rule.displayName != "" {
+			buf.WriteString("rule " + rule.displayName)
+		} else {
+			buf.WriteString("rule " + rule.name)
+		}
+	}
+	pe := &parserError{Inner: err, pos: pos, prefix: buf.String(), expected: expected}
+	p.errs.add(pe)
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = p.maxFailExpected[:0]
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected = append(p.maxFailExpected, want)
+	}
+}
+
+// read advances the parser to the next rune.
+func (p *parser) read() {
+	p.pt.offset += p.pt.w
+	rn, n := utf8.DecodeRune(p.data[p.pt.offset:])
+	p.pt.rn = rn
+	p.pt.w = n
+	p.pt.col++
+	if rn == '\n' {
+		p.pt.line++
+		p.pt.col = 0
+	}
+
+	if rn == utf8.RuneError {
+		if n == 1 {
+			p.addErr(errInvalidEncoding)
+		}
+	}
+}
+
+// restore parser position to the savepoint pt.
+func (p *parser) restore(pt savepoint) {
+	if p.debug {
+		defer p.out(p.in("restore"))
+	}
+	if pt.offset == p.pt.offset {
+		return
+	}
+	p.pt = pt
+}
+
+// get the slice of bytes from the savepoint start to the current position.
+func (p *parser) sliceFrom(start savepoint) []byte {
+	return p.data[start.position.offset:p.pt.position.offset]
+}
+
+func (p *parser) getMemoized(node interface{}) (resultTuple, bool) {
+	if len(p.memo) == 0 {
+		return resultTuple{}, false
+	}
+	m := p.memo[p.pt.offset]
+	if len(m) == 0 {
+		return resultTuple{}, false
+	}
+	res, ok := m[node]
+	return res, ok
+}
+
+func (p *parser) setMemoized(pt savepoint, node interface{}, tuple resultTuple) {
+	if p.memo == nil {
+		p.memo = make(map[int]map[interface{}]resultTuple)
+	}
+	m := p.memo[pt.offset]
+	if m == nil {
+		m = make(map[interface{}]resultTuple)
+		p.memo[pt.offset] = m
+	}
+	m[node] = tuple
+}
+
+func (p *parser) buildRulesTable(g *grammar) {
+	p.rules = make(map[string]*rule, len(g.rules))
+	for _, r := range g.rules {
+		p.rules[r.name] = r
+	}
+}
+
+func (p *parser) parse(g *grammar) (val interface{}, err error) {
+	if len(g.rules) == 0 {
+		p.addErr(errNoRule)
+		return nil, p.errs.err()
+	}
+
+	// TODO : not super critical but this could be generated
+	p.buildRulesTable(g)
+
+	if p.recover {
+		// panic can be used in action code to stop parsing immediately
+		// and return the panic as an error.
+		defer func() {
+			if e := recover(); e != nil {
+				if p.debug {
+					defer p.out(p.in("panic handler"))
+				}
+				val = nil
+				switch e := e.(type) {
+				case error:
+					p.addErr(e)
+				default:
+					p.addErr(fmt.Errorf("%v", e))
+				}
+				err = p.errs.err()
+			}
+		}()
+	}
+
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
+	p.read() // advance to first rune
+	val, ok := p.parseRule(startRule)
+	if !ok {
+		if len(*p.errs) == 0 {
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			maxFailExpectedMap := make(map[string]struct{}, len(p.maxFailExpected))
+			for _, v := range p.maxFailExpected {
+				maxFailExpectedMap[v] = struct{}{}
+			}
+			expected := make([]string, 0, len(maxFailExpectedMap))
+			eof := false
+			if _, ok := maxFailExpectedMap["!."]; ok {
+				delete(maxFailExpectedMap, "!.")
+				eof = true
+			}
+			for k := range maxFailExpectedMap {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			if eof {
+				expected = append(expected, "EOF")
+			}
+			p.addErrAt(errors.New("no match found, expected: "+listJoin(expected, ", ", "or")), p.maxFailPos, expected)
+		}
+
+		return nil, p.errs.err()
+	}
+	return val, p.errs.err()
+}
+
+func listJoin(list []string, sep string, lastSep string) string {
+	switch len(list) {
+	case 0:
+		return ""
+	case 1:
+		return list[0]
+	default:
+		return fmt.Sprintf("%s %s %s", strings.Join(list[:len(list)-1], sep), lastSep, list[len(list)-1])
+	}
+}
+
+func (p *parser) parseRule(rule *rule) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseRule " + rule.name))
+	}
+
+	if p.memoize {
+		res, ok := p.getMemoized(rule)
+		if ok {
+			p.restore(res.end)
+			return res.v, res.b
+		}
+	}
+
+	start := p.pt
+	p.rstack = append(p.rstack, rule)
+	p.pushV()
+	val, ok := p.parseExpr(rule.expr)
+	p.popV()
+	p.rstack = p.rstack[:len(p.rstack)-1]
+	if ok && p.debug {
+		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
+	}
+
+	if p.memoize {
+		p.setMemoized(start, rule, resultTuple{val, ok, p.pt})
+	}
+	return val, ok
+}
+
+func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
+	var pt savepoint
+
+	if p.memoize {
+		res, ok := p.getMemoized(expr)
+		if ok {
+			p.restore(res.end)
+			return res.v, res.b
+		}
+		pt = p.pt
+	}
+
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
+		panic(errMaxExprCnt)
+	}
+
+	var val interface{}
+	var ok bool
+	switch expr := expr.(type) {
+	case *actionExpr:
+		val, ok = p.parseActionExpr(expr)
+	case *andCodeExpr:
+		val, ok = p.parseAndCodeExpr(expr)
+	case *andExpr:
+		val, ok = p.parseAndExpr(expr)
+	case *anyMatcher:
+		val, ok = p.parseAnyMatcher(expr)
+	case *charClassMatcher:
+		val, ok = p.parseCharClassMatcher(expr)
+	case *choiceExpr:
+		val, ok = p.parseChoiceExpr(expr)
+	case *labeledExpr:
+		val, ok = p.parseLabeledExpr(expr)
+	case *litMatcher:
+		val, ok = p.parseLitMatcher(expr)
+	case *notCodeExpr:
+		val, ok = p.parseNotCodeExpr(expr)
+	case *notExpr:
+		val, ok = p.parseNotExpr(expr)
+	case *oneOrMoreExpr:
+		val, ok = p.parseOneOrMoreExpr(expr)
+	case *recoveryExpr:
+		val, ok = p.parseRecoveryExpr(expr)
+	case *ruleRefExpr:
+		val, ok = p.parseRuleRefExpr(expr)
+	case *seqExpr:
+		val, ok = p.parseSeqExpr(expr)
+	case *throwExpr:
+		val, ok = p.parseThrowExpr(expr)
+	case *zeroOrMoreExpr:
+		val, ok = p.parseZeroOrMoreExpr(expr)
+	case *zeroOrOneExpr:
+		val, ok = p.parseZeroOrOneExpr(expr)
+	default:
+		panic(fmt.Sprintf("unknown expression type %T", expr))
+	}
+	if p.memoize {
+		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
+	}
+	return val, ok
+}
+
+func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseActionExpr"))
+	}
+
+	start := p.pt
+	val, ok := p.parseExpr(act.expr)
+	if ok {
+		p.cur.pos = start.position
+		p.cur.text = p.sliceFrom(start)
+		actVal, err := act.run(p)
+		if err != nil {
+			p.addErrAt(err, start.position, []string{})
+		}
+		val = actVal
+	}
+	if ok && p.debug {
+		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
+	}
+	return val, ok
+}
+
+func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseAndCodeExpr"))
+	}
+
+	ok, err := and.run(p)
+	if err != nil {
+		p.addErr(err)
+	}
+	return nil, ok
+}
+
+func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseAndExpr"))
+	}
+
+	pt := p.pt
+	p.pushV()
+	_, ok := p.parseExpr(and.expr)
+	p.popV()
+	p.restore(pt)
+	return nil, ok
+}
+
+func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseAnyMatcher"))
+	}
+
+	if p.pt.rn != utf8.RuneError {
+		start := p.pt
+		p.read()
+		p.failAt(true, start.position, ".")
+		return p.sliceFrom(start), true
+	}
+	p.failAt(false, p.pt.position, ".")
+	return nil, false
+}
+
+func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseCharClassMatcher"))
+	}
+
+	cur := p.pt.rn
+	start := p.pt
+
+	// can't match EOF
+	if cur == utf8.RuneError {
+		p.failAt(false, start.position, chr.val)
+		return nil, false
+	}
+
+	if chr.ignoreCase {
+		cur = unicode.ToLower(cur)
+	}
+
+	// try to match in the list of available chars
+	for _, rn := range chr.chars {
+		if rn == cur {
+			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
+				return nil, false
+			}
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+	}
+
+	// try to match in the list of ranges
+	for i := 0; i < len(chr.ranges); i += 2 {
+		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
+			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
+				return nil, false
+			}
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+	}
+
+	// try to match in the list of Unicode classes
+	for _, cl := range chr.classes {
+		if unicode.Is(cl, cur) {
+			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
+				return nil, false
+			}
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+	}
+
+	if chr.inverted {
+		p.read()
+		p.failAt(true, start.position, chr.val)
+		return p.sliceFrom(start), true
+	}
+	p.failAt(false, start.position, chr.val)
+	return nil, false
+}
+
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
+	}
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = p.choiceNoMatch
+	}
+	m[alt]++
+}
+
+func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseChoiceExpr"))
+	}
+
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
+		p.pushV()
+		val, ok := p.parseExpr(alt)
+		p.popV()
+		if ok {
+			p.incChoiceAltCnt(ch, altI)
+			return val, ok
+		}
+	}
+	p.incChoiceAltCnt(ch, choiceNoMatch)
+	return nil, false
+}
+
+func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseLabeledExpr"))
+	}
+
+	p.pushV()
+	val, ok := p.parseExpr(lab.expr)
+	p.popV()
+	if ok && lab.label != "" {
+		m := p.vstack[len(p.vstack)-1]
+		m[lab.label] = val
+	}
+	return val, ok
+}
+
+func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseLitMatcher"))
+	}
+
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
+	start := p.pt
+	for _, want := range lit.val {
+		cur := p.pt.rn
+		if lit.ignoreCase {
+			cur = unicode.ToLower(cur)
+		}
+		if cur != want {
+			p.failAt(false, start.position, val)
+			p.restore(start)
+			return nil, false
+		}
+		p.read()
+	}
+	p.failAt(true, start.position, val)
+	return p.sliceFrom(start), true
+}
+
+func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseNotCodeExpr"))
+	}
+
+	ok, err := not.run(p)
+	if err != nil {
+		p.addErr(err)
+	}
+	return nil, !ok
+}
+
+func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseNotExpr"))
+	}
+
+	pt := p.pt
+	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
+	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
+	p.popV()
+	p.restore(pt)
+	return nil, !ok
+}
+
+func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseOneOrMoreExpr"))
+	}
+
+	var vals []interface{}
+
+	for {
+		p.pushV()
+		val, ok := p.parseExpr(expr.expr)
+		p.popV()
+		if !ok {
+			if len(vals) == 0 {
+				// did not match once, no match
+				return nil, false
+			}
+			return vals, true
+		}
+		vals = append(vals, val)
+	}
+}
+
+func (p *parser) parseRecoveryExpr(recover *recoveryExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseRecoveryExpr (" + strings.Join(recover.failureLabel, ",") + ")"))
+	}
+
+	p.pushRecovery(recover.failureLabel, recover.recoverExpr)
+	val, ok := p.parseExpr(recover.expr)
+	p.popRecovery()
+
+	return val, ok
+}
+
+func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseRuleRefExpr " + ref.name))
+	}
+
+	if ref.name == "" {
+		panic(fmt.Sprintf("%s: invalid rule: missing name", ref.pos))
+	}
+
+	rule := p.rules[ref.name]
+	if rule == nil {
+		p.addErr(fmt.Errorf("undefined rule: %s", ref.name))
+		return nil, false
+	}
+	return p.parseRule(rule)
+}
+
+func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseSeqExpr"))
+	}
+
+	vals := make([]interface{}, 0, len(seq.exprs))
+
+	pt := p.pt
+	for _, expr := range seq.exprs {
+		val, ok := p.parseExpr(expr)
+		if !ok {
+			p.restore(pt)
+			return nil, false
+		}
+		vals = append(vals, val)
+	}
+	return vals, true
+}
+
+func (p *parser) parseThrowExpr(expr *throwExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseThrowExpr"))
+	}
+
+	for i := len(p.recoveryStack) - 1; i >= 0; i-- {
+		if recoverExpr, ok := p.recoveryStack[i][expr.label]; ok {
+			if val, ok := p.parseExpr(recoverExpr); ok {
+				return val, ok
+			}
+		}
+	}
+
+	return nil, false
+}
+
+func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseZeroOrMoreExpr"))
+	}
+
+	var vals []interface{}
+
+	for {
+		p.pushV()
+		val, ok := p.parseExpr(expr.expr)
+		p.popV()
+		if !ok {
+			return vals, true
+		}
+		vals = append(vals, val)
+	}
+}
+
+func (p *parser) parseZeroOrOneExpr(expr *zeroOrOneExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseZeroOrOneExpr"))
+	}
+
+	p.pushV()
+	val, _ := p.parseExpr(expr.expr)
+	p.popV()
+	// whether it matched or not, consider it a match
+	return val, true
+}

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -250,15 +250,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -571,6 +575,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -876,18 +882,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -795,10 +795,8 @@ func (p *parser) read() {
 		p.pt.col = 0
 	}
 
-	if rn == utf8.RuneError {
-		if n == 1 {
-			p.addErr(errInvalidEncoding)
-		}
+	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
+		p.addErr(errInvalidEncoding)
 	}
 }
 
@@ -1074,7 +1072,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError {
+	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
 		start := p.pt
 		p.read()
 		p.failAt(true, start.position, ".")
@@ -1093,7 +1091,7 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	start := p.pt
 
 	// can't match EOF
-	if cur == utf8.RuneError {
+	if cur == utf8.RuneError && p.pt.w == 0 { // see utf8.DecodeRune
 		p.failAt(false, start.position, chr.val)
 		return nil, false
 	}

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -27,25 +27,29 @@ var g = &grammar{
 					pos: position{line: 5, col: 11, offset: 46},
 					exprs: []interface{}{
 						&oneOrMoreExpr{
-							pos: position{line: 13, col: 6, offset: 129},
+							pos: position{line: 17, col: 6, offset: 171},
 							expr: &litMatcher{
-								pos:        position{line: 13, col: 6, offset: 129},
+								pos:        position{line: 17, col: 6, offset: 171},
 								val:        "a",
 								ignoreCase: false,
 							},
 						},
-						&oneOrMoreExpr{
-							pos: position{line: 15, col: 6, offset: 149},
-							expr: &litMatcher{
-								pos:        position{line: 15, col: 6, offset: 149},
-								val:        "c",
-								ignoreCase: false,
+						&actionExpr{
+							pos: position{line: 19, col: 6, offset: 191},
+							run: (*parser).callonEntry15,
+							expr: &oneOrMoreExpr{
+								pos: position{line: 19, col: 6, offset: 191},
+								expr: &litMatcher{
+									pos:        position{line: 19, col: 6, offset: 191},
+									val:        "c",
+									ignoreCase: false,
+								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 17, col: 7, offset: 163},
+							pos: position{line: 23, col: 7, offset: 230},
 							expr: &anyMatcher{
-								line: 17, col: 8, offset: 164,
+								line: 23, col: 8, offset: 231,
 							},
 						},
 					},
@@ -62,32 +66,93 @@ var g = &grammar{
 					pos: position{line: 9, col: 11, offset: 90},
 					exprs: []interface{}{
 						&oneOrMoreExpr{
-							pos: position{line: 14, col: 6, offset: 139},
+							pos: position{line: 18, col: 6, offset: 181},
 							expr: &litMatcher{
-								pos:        position{line: 14, col: 6, offset: 139},
+								pos:        position{line: 18, col: 6, offset: 181},
 								val:        "b",
 								ignoreCase: false,
 							},
 						},
-						&oneOrMoreExpr{
-							pos: position{line: 15, col: 6, offset: 149},
-							expr: &litMatcher{
-								pos:        position{line: 15, col: 6, offset: 149},
-								val:        "c",
-								ignoreCase: false,
+						&actionExpr{
+							pos: position{line: 19, col: 6, offset: 191},
+							run: (*parser).callonEntry25,
+							expr: &oneOrMoreExpr{
+								pos: position{line: 19, col: 6, offset: 191},
+								expr: &litMatcher{
+									pos:        position{line: 19, col: 6, offset: 191},
+									val:        "c",
+									ignoreCase: false,
+								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 17, col: 7, offset: 163},
+							pos: position{line: 23, col: 7, offset: 230},
 							expr: &anyMatcher{
-								line: 17, col: 8, offset: 164,
+								line: 23, col: 8, offset: 231,
 							},
 						},
 					},
 				},
 			},
 		},
+		{
+			name: "Entry3",
+			pos:  position{line: 13, col: 1, offset: 124},
+			expr: &actionExpr{
+				pos: position{line: 13, col: 11, offset: 134},
+				run: (*parser).callonEntry31,
+				expr: &seqExpr{
+					pos: position{line: 13, col: 11, offset: 134},
+					exprs: []interface{}{
+						&actionExpr{
+							pos: position{line: 19, col: 6, offset: 191},
+							run: (*parser).callonEntry33,
+							expr: &oneOrMoreExpr{
+								pos: position{line: 19, col: 6, offset: 191},
+								expr: &litMatcher{
+									pos:        position{line: 19, col: 6, offset: 191},
+									val:        "c",
+									ignoreCase: false,
+								},
+							},
+						},
+						&notExpr{
+							pos: position{line: 23, col: 7, offset: 230},
+							expr: &anyMatcher{
+								line: 23, col: 8, offset: 231,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "C",
+			pos:  position{line: 19, col: 1, offset: 186},
+			expr: &actionExpr{
+				pos: position{line: 19, col: 6, offset: 191},
+				run: (*parser).callonC1,
+				expr: &oneOrMoreExpr{
+					pos: position{line: 19, col: 6, offset: 191},
+					expr: &litMatcher{
+						pos:        position{line: 19, col: 6, offset: 191},
+						val:        "c",
+						ignoreCase: false,
+					},
+				},
+			},
+		},
 	},
+}
+
+func (c *current) onEntry15() (interface{}, error) {
+	return c.text, nil
+}
+
+func (p *parser) callonEntry15() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onEntry15()
 }
 
 func (c *current) onEntry11() (interface{}, error) {
@@ -100,6 +165,16 @@ func (p *parser) callonEntry11() (interface{}, error) {
 	return p.cur.onEntry11()
 }
 
+func (c *current) onEntry25() (interface{}, error) {
+	return c.text, nil
+}
+
+func (p *parser) callonEntry25() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onEntry25()
+}
+
 func (c *current) onEntry21() (interface{}, error) {
 	return c.text, nil
 }
@@ -108,6 +183,36 @@ func (p *parser) callonEntry21() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEntry21()
+}
+
+func (c *current) onEntry33() (interface{}, error) {
+	return c.text, nil
+}
+
+func (p *parser) callonEntry33() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onEntry33()
+}
+
+func (c *current) onEntry31() (interface{}, error) {
+	return c.text, nil
+}
+
+func (p *parser) callonEntry31() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onEntry31()
+}
+
+func (c *current) onC1() (interface{}, error) {
+	return c.text, nil
+}
+
+func (p *parser) callonC1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onC1()
 }
 
 var (

--- a/test/alternate_entrypoint/altentry.peg
+++ b/test/alternate_entrypoint/altentry.peg
@@ -1,0 +1,18 @@
+{
+  package alternate_entrypoint
+}
+
+Entry1 <- A C EOF {
+  return c.text, nil
+}
+
+Entry2 <- B C EOF {
+  return c.text, nil
+}
+
+A <- 'a'+
+B <- 'b'+
+C <- 'c'+
+
+EOF ← !.
+

--- a/test/alternate_entrypoint/altentry.peg
+++ b/test/alternate_entrypoint/altentry.peg
@@ -10,9 +10,15 @@ Entry2 <- B C EOF {
   return c.text, nil
 }
 
+Entry3 <- C EOF {
+  return c.text, nil
+}
+
 A <- 'a'+
 B <- 'b'+
-C <- 'c'+
+C <- 'c'+ {
+  return c.text, nil
+}
 
 EOF ← !.
 

--- a/test/alternate_entrypoint/altentry_test.go
+++ b/test/alternate_entrypoint/altentry_test.go
@@ -1,0 +1,44 @@
+package alternate_entrypoint
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAlternateEntrypoint(t *testing.T) {
+	src := "bbbcc"
+
+	v, err := Parse("", []byte(src), Entrypoint("Entry2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := string(v.([]byte))
+	if got != src {
+		t.Fatalf("want %s, got %s", src, got)
+	}
+}
+
+func TestAlternateInputWithDefaultEntrypoint(t *testing.T) {
+	src := "bbbcc"
+
+	_, err := Parse("", []byte(src))
+	if err == nil {
+		t.Fatal("want error, got none")
+	}
+	if !strings.Contains(err.Error(), "no match found") {
+		t.Fatalf("want 'no match found', got %s", err)
+	}
+}
+
+func TestDefaultInputWithAlternateEntrypoint(t *testing.T) {
+	src := "aacc"
+
+	_, err := Parse("", []byte(src), Entrypoint("Entry2"))
+	if err == nil {
+		t.Fatal("want error, got none")
+	}
+	if !strings.Contains(err.Error(), "no match found") {
+		t.Fatalf("want 'no match found', got %s", err)
+	}
+}

--- a/test/alternate_entrypoint/altentry_test.go
+++ b/test/alternate_entrypoint/altentry_test.go
@@ -5,52 +5,52 @@ import (
 	"testing"
 )
 
-func TestAlternateEntrypoint(t *testing.T) {
-	src := "bbbcc"
-
-	v, err := Parse("", []byte(src), Entrypoint("Entry2"))
-	if err != nil {
-		t.Fatal(err)
+func TestValidEntrypoints(t *testing.T) {
+	cases := []struct {
+		in         string
+		entrypoint string
+	}{
+		{"aacc", ""},
+		{"bbbcc", "Entry2"},
+		{"cc", "Entry3"},
+		{"cc", "C"},
 	}
 
-	got := string(v.([]byte))
-	if got != src {
-		t.Fatalf("want %s, got %s", src, got)
-	}
-}
+	for _, c := range cases {
+		v, err := Parse("", []byte(c.in), Entrypoint(c.entrypoint))
+		if err != nil {
+			t.Errorf("%s:%s: got error %s", c.entrypoint, c.in, err)
+		}
 
-func TestInvalidAlternateEntrypoint(t *testing.T) {
-	src := "bbbcc"
-
-	_, err := Parse("", []byte(src), Entrypoint("Z"))
-	if err == nil {
-		t.Fatal("want error, got none")
-	}
-	if !strings.Contains(err.Error(), errInvalidEntrypoint.Error()) {
-		t.Fatalf("want %s, got %s", errInvalidEntrypoint, err)
+		got := string(v.([]byte))
+		if got != c.in {
+			t.Errorf("%s:%s: got %s", c.entrypoint, c.in, got)
+		}
 	}
 }
 
-func TestAlternateInputWithDefaultEntrypoint(t *testing.T) {
-	src := "bbbcc"
-
-	_, err := Parse("", []byte(src))
-	if err == nil {
-		t.Fatal("want error, got none")
+func TestInvalidEntrypoints(t *testing.T) {
+	cases := []struct {
+		in         string
+		entrypoint string
+		errMsg     string
+	}{
+		{"bbbcc", "Z", errInvalidEntrypoint.Error()},
+		{"bbbcc", "", "no match found"},
+		{"bbbcc", "C", "no match found"},
+		{"aacc", "Entry2", "no match found"},
+		{"aacc", "C", "no match found"},
+		{"cc", "", "no match found"},
+		{"cc", "Entry2", "no match found"},
 	}
-	if !strings.Contains(err.Error(), "no match found") {
-		t.Fatalf("want 'no match found', got %s", err)
-	}
-}
 
-func TestDefaultInputWithAlternateEntrypoint(t *testing.T) {
-	src := "aacc"
-
-	_, err := Parse("", []byte(src), Entrypoint("Entry2"))
-	if err == nil {
-		t.Fatal("want error, got none")
-	}
-	if !strings.Contains(err.Error(), "no match found") {
-		t.Fatalf("want 'no match found', got %s", err)
+	for _, c := range cases {
+		_, err := Parse("", []byte(c.in), Entrypoint(c.entrypoint))
+		if err == nil {
+			t.Errorf("%s:%s: want error, got none", c.entrypoint, c.in)
+		}
+		if !strings.Contains(err.Error(), c.errMsg) {
+			t.Errorf("%s:%s: want %s, got %s", c.entrypoint, c.in, c.errMsg, err)
+		}
 	}
 }

--- a/test/alternate_entrypoint/altentry_test.go
+++ b/test/alternate_entrypoint/altentry_test.go
@@ -42,6 +42,9 @@ func TestInvalidEntrypoints(t *testing.T) {
 		{"aacc", "C", "no match found"},
 		{"cc", "", "no match found"},
 		{"cc", "Entry2", "no match found"},
+		// rules A and B are optimized away and not specified as alternate entrypoints
+		{"aa", "A", errInvalidEntrypoint.Error()},
+		{"bb", "B", errInvalidEntrypoint.Error()},
 	}
 
 	for _, c := range cases {

--- a/test/alternate_entrypoint/altentry_test.go
+++ b/test/alternate_entrypoint/altentry_test.go
@@ -19,6 +19,18 @@ func TestAlternateEntrypoint(t *testing.T) {
 	}
 }
 
+func TestInvalidAlternateEntrypoint(t *testing.T) {
+	src := "bbbcc"
+
+	_, err := Parse("", []byte(src), Entrypoint("Z"))
+	if err == nil {
+		t.Fatal("want error, got none")
+	}
+	if !strings.Contains(err.Error(), errInvalidEntrypoint.Error()) {
+		t.Fatalf("want %s, got %s", errInvalidEntrypoint, err)
+	}
+}
+
 func TestAlternateInputWithDefaultEntrypoint(t *testing.T) {
 	src := "bbbcc"
 

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -182,6 +182,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -839,6 +843,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -208,6 +208,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -594,6 +596,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -819,6 +822,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -580,6 +580,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -1237,6 +1241,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -606,6 +606,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -992,6 +994,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -1217,6 +1220,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -611,15 +611,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -932,6 +936,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -1237,18 +1243,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -606,7 +606,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -994,7 +1006,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -1220,10 +1233,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -218,7 +218,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -606,7 +618,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -832,10 +845,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -218,6 +218,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -604,6 +606,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -829,6 +832,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -223,15 +223,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -544,6 +548,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -849,18 +855,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -192,6 +192,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -849,6 +853,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -426,6 +426,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -812,6 +814,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -1037,6 +1040,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -400,6 +400,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -1057,6 +1061,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -431,15 +431,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -752,6 +756,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -1057,18 +1063,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -426,7 +426,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -814,7 +826,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -1040,10 +1053,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -113,6 +113,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -770,6 +774,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -144,15 +144,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -465,6 +469,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -770,18 +776,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -139,6 +139,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -525,6 +527,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -750,6 +753,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -139,7 +139,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -527,7 +539,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -753,10 +766,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -122,6 +122,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -779,6 +783,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -148,7 +148,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -536,7 +548,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -762,10 +775,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -148,6 +148,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -534,6 +536,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -759,6 +762,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -153,15 +153,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -474,6 +478,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -779,18 +785,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -342,6 +342,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -999,6 +1003,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -368,6 +368,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -754,6 +756,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -979,6 +982,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -373,15 +373,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -694,6 +698,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -999,18 +1005,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -368,7 +368,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -756,7 +768,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -982,10 +995,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -226,7 +226,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -614,7 +626,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -840,10 +853,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -231,15 +231,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -552,6 +556,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -857,18 +863,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -200,6 +200,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -857,6 +861,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -226,6 +226,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -612,6 +614,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -837,6 +840,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -61,7 +61,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -449,7 +461,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -675,10 +688,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -35,6 +35,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -692,6 +696,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -61,6 +61,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -447,6 +449,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -672,6 +675,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -66,15 +66,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -387,6 +391,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -692,18 +698,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -279,15 +279,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -600,6 +604,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -905,18 +911,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -274,6 +274,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -660,6 +662,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -885,6 +888,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -274,7 +274,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -662,7 +674,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -888,10 +901,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -248,6 +248,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -905,6 +909,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -62,6 +62,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -719,6 +723,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -88,7 +88,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -476,7 +488,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -702,10 +715,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -88,6 +88,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -474,6 +476,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -699,6 +702,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -93,15 +93,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -414,6 +418,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -719,18 +725,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -1153,6 +1153,8 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
+// TODO(mna): add a func Entrypoint(rule string) Option
+
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
 // Also the key for the "no match" counter is set.
@@ -1539,6 +1541,7 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
+	// TODO(mna): add entrypoint string field, use default if empty
 
 	*Stats
 
@@ -1764,6 +1767,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
+	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
 	// start rule is rule [0]
 	p.read() // advance to first rune
 	val, ok := p.parseRule(g.rules[0])

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -1158,15 +1158,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 }
 
 // Entrypoint creates an Option to set the rule name to use as entrypoint.
-// The rule name must have been set with the -alternate-entrypoints flag
-// when generating the parser, otherwise it may have been optimized out
-// if the -optimize-grammar flag was set.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
 //
 // The default is to start parsing at the first rule in the grammar.
 func Entrypoint(ruleName string) Option {
 	return func(p *parser) Option {
 		oldEntrypoint := p.entrypoint
 		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
 		return Entrypoint(oldEntrypoint)
 	}
 }
@@ -1479,6 +1483,8 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		maxFailPos:      position{col: 1, line: 1},
 		maxFailExpected: make([]string, 0, 20),
 		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
 	}
 	p.setOptions(opts)
 
@@ -1784,18 +1790,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// start rule is rule [0] unless an alternate entrypoint is specified
-	startRule := g.rules[0]
-	if p.entrypoint != "" {
-		startRule = p.rules[p.entrypoint]
-		if startRule == nil {
-			p.addErr(errInvalidEntrypoint)
-			return nil, p.errs.err()
-		}
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
 	}
 
 	p.read() // advance to first rune
-	val, ok := p.parseRule(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -1127,6 +1127,10 @@ var (
 	// errNoRule is returned when the grammar to parse has no rule.
 	errNoRule = errors.New("grammar has no rule")
 
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
 	// errInvalidEncoding is returned when the source is not properly
 	// utf8-encoded.
 	errInvalidEncoding = errors.New("invalid encoding")
@@ -1784,6 +1788,10 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	startRule := g.rules[0]
 	if p.entrypoint != "" {
 		startRule = p.rules[p.entrypoint]
+		if startRule == nil {
+			p.addErr(errInvalidEntrypoint)
+			return nil, p.errs.err()
+		}
 	}
 
 	p.read() // advance to first rune

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -1153,7 +1153,19 @@ func MaxExpressions(maxExprCnt uint64) Option {
 	}
 }
 
-// TODO(mna): add a func Entrypoint(rule string) Option
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been set with the -alternate-entrypoints flag
+// when generating the parser, otherwise it may have been optimized out
+// if the -optimize-grammar flag was set.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		return Entrypoint(oldEntrypoint)
+	}
+}
 
 // Statistics adds a user provided Stats struct to the parser to allow
 // the user to process the results after the parsing has finished.
@@ -1541,7 +1553,8 @@ type parser struct {
 
 	// max number of expressions to be parsed
 	maxExprCnt uint64
-	// TODO(mna): add entrypoint string field, use default if empty
+	// entrypoint for the parser
+	entrypoint string
 
 	*Stats
 
@@ -1767,10 +1780,14 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		}()
 	}
 
-	// TODO(mna): if p.entrypoint != "", start at rule p.rules[p.entrypoint]
-	// start rule is rule [0]
+	// start rule is rule [0] unless an alternate entrypoint is specified
+	startRule := g.rules[0]
+	if p.entrypoint != "" {
+		startRule = p.rules[p.entrypoint]
+	}
+
 	p.read() // advance to first rune
-	val, ok := p.parseRule(g.rules[0])
+	val, ok := p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values


### PR DESCRIPTION
This is the companion PR to issue #44 . See the issue for an overview of the problem it solves. The implementation is mostly complete (as described in #44), with documentation and tests, there's one TODO left to optimize validation that the alternate entrypoints are valid rule names, I'll address it if the PR looks good otherwise.
