### PR TITLE
Add AllowInvalidUTF8 option

### DIFF
--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2277,6 +2277,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -2639,6 +2653,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -2786,7 +2802,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -3108,14 +3126,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -116,6 +116,20 @@ func Memoize(b bool) Option {
 
 // {{ end }} ==template==
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -480,6 +494,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -630,7 +646,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -988,14 +1006,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	}
 
 	// {{ end }} ==template==
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -132,6 +132,20 @@ func Memoize(b bool) Option {
 
 // {{ end }} ==template==
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -496,6 +510,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -646,7 +662,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1004,14 +1022,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	}
 
 	// {{ end }} ==template==
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/doc.go
+++ b/doc.go
@@ -424,6 +424,7 @@ as a package with public functions to parse input text. The exported API is:
 	- Parse(string, []byte, ...Option) (interface{}, error)
 	- ParseFile(string, ...Option) (interface{}, error)
 	- ParseReader(string, io.Reader, ...Option) (interface{}, error)
+	- AllowInvalidUTF8(bool) Option
 	- Debug(bool) Option
 	- Entrypoint(string) Option
 	- GlobalStore(string, interface{}) Option

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -555,6 +555,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -917,6 +931,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -1064,7 +1080,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1386,14 +1404,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/examples/indentation/indentation.go
+++ b/examples/indentation/indentation.go
@@ -862,6 +862,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -1224,6 +1238,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -1371,7 +1387,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1693,14 +1711,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -849,6 +849,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -1211,6 +1225,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -1358,7 +1374,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1680,14 +1698,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -1020,6 +1020,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -1382,6 +1396,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -1529,7 +1545,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1851,14 +1869,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/pigeon.go
+++ b/pigeon.go
@@ -3213,6 +3213,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -3575,6 +3589,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -3722,7 +3738,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -4044,14 +4062,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/targeted_test.go
+++ b/targeted_test.go
@@ -44,7 +44,7 @@ func TestParseAnyMatcher(t *testing.T) {
 		{"ab", []byte("a")},
 		{"\u2190\U00001100", []byte("\u2190")},
 		{"\x0d", []byte("\x0d")},
-		{"\xfa", nil},
+		{"\xfa", []byte("\xfa")},
 		{"\nab", []byte("\n")},
 	}
 

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -324,6 +324,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -686,6 +700,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -833,7 +849,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1155,14 +1173,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -287,6 +287,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -649,6 +663,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -796,7 +812,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1118,14 +1136,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -685,6 +685,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -1047,6 +1061,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -1194,7 +1210,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1516,14 +1534,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -297,6 +297,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -659,6 +673,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -806,7 +822,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1128,14 +1146,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -505,6 +505,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -867,6 +881,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -1014,7 +1030,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1336,14 +1354,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/goto_state/goto_state.go
+++ b/test/goto_state/goto_state.go
@@ -533,6 +533,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -895,6 +909,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -1042,7 +1058,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1364,14 +1382,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -218,6 +218,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -580,6 +594,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -727,7 +743,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1049,14 +1067,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -227,6 +227,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -589,6 +603,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -736,7 +752,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1058,14 +1076,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -447,6 +447,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -809,6 +823,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -956,7 +972,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1278,14 +1296,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -305,6 +305,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -667,6 +681,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -814,7 +830,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1136,14 +1154,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -140,6 +140,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -502,6 +516,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -649,7 +665,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -971,14 +989,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -353,6 +353,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -715,6 +729,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -862,7 +878,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1184,14 +1202,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/runeerror/runeerror.peg
+++ b/test/runeerror/runeerror.peg
@@ -1,6 +1,18 @@
 {
     package main
+
+    func joinBytes(a interface{}) []byte {
+        var A []byte
+        for _, x := range a.([]interface{}) {
+            A = append(A, x.([]uint8)...)
+        }
+        return A
+    }
 }
 
-Program <- '\n' [^\n]+ '\n' . !.
+Program <- '\n' a:[^\n]+ '\n' b:. !. {
+    return [][]byte{
+        c.text, joinBytes(a), b.([]uint8),
+    }, nil
+}
 

--- a/test/runeerror/runeerror_test.go
+++ b/test/runeerror/runeerror_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -9,16 +10,32 @@ var tc = `
 This is a real U+FFFD: "�"
 �`
 
-var invalid = []byte{0xff, 0xfe, 0xfd}
+var invalid = []byte{'\n', 0xff, 0xfe, 0xfd, '\n', 0xfe}
 
 func TestRuneError(t *testing.T) {
-	if _, err := Parse("", []byte(tc)); err != nil {
+	v, err := Parse("", []byte(tc))
+	if err != nil {
 		t.Error("Parsing failed:", err)
+	}
+	if !reflect.DeepEqual(v, [][]byte{
+		[]byte(tc), []byte(`This is a real U+FFFD: "�"`), []byte(`�`),
+	}) {
+		t.Error("Wrong result:", v)
 	}
 
 	if _, err := Parse("", invalid); err == nil {
 		t.Error("Did not fail parsing invalid encoding")
 	} else if !strings.Contains(err.Error(), "invalid encoding") {
 		t.Error("Unexpected error:", err)
+	}
+
+	v, err = Parse("", invalid, AllowInvalidUTF8(true))
+	if err != nil {
+		t.Error("Unexpected error:", err)
+	}
+	if !reflect.DeepEqual(v, [][]byte{
+		invalid, []byte{0xff, 0xfe, 0xfd}, []byte{0xfe},
+	}) {
+		t.Error("Wrong result:", v)
 	}
 }

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -370,6 +370,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -732,6 +746,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -879,7 +895,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1201,14 +1219,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/stateclone/stateclone.go
+++ b/test/stateclone/stateclone.go
@@ -380,6 +380,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -742,6 +756,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -889,7 +905,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1211,14 +1229,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/statereadonly/statereadonly.go
+++ b/test/statereadonly/statereadonly.go
@@ -361,6 +361,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -723,6 +737,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -870,7 +886,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -1192,14 +1210,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -1232,6 +1232,20 @@ func Memoize(b bool) Option {
 	}
 }
 
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
 // Recover creates an Option to set the recover flag to b. When set to
 // true, this causes the parser to recover from panics and convert it
 // to an error. Setting it to false can be useful while debugging to
@@ -1594,6 +1608,8 @@ type parser struct {
 	// entrypoint for the parser
 	entrypoint string
 
+	allowInvalidUTF8 bool
+
 	*Stats
 
 	choiceNoMatch string
@@ -1741,7 +1757,9 @@ func (p *parser) read() {
 	}
 
 	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
-		p.addErr(errInvalidEncoding)
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
 	}
 }
 
@@ -2063,14 +2081,15 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
 
-	if p.pt.rn != utf8.RuneError || p.pt.w > 1 { // see utf8.DecodeRune
-		start := p.pt
-		p.read()
-		p.failAt(true, start.position, ".")
-		return p.sliceFrom(start), true
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
 	}
-	p.failAt(false, p.pt.position, ".")
-	return nil, false
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {


### PR DESCRIPTION
This option allows parsers to be used on documents that contain invalid UTF-8.

The invalid bytes match the any matcher and behave like a U+FFFD for the character class matcher.

The actual U+FFFD is never returned, the invalid bytes are instead. This allows to validate for example signatures on the partially invalid text.