### PR TITLE
optimize global state if not used

### DIFF
--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -3231,6 +3231,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -154,6 +154,8 @@ func GlobalStore(key string, value interface{}) Option {
 	}
 }
 
+// ==template== {{ if or .GlobalState (not .Optimize) }}
+
 // InitState creates an Option to set a key to a certain value in
 // the global "state" store.
 func InitState(key string, value interface{}) Option {
@@ -163,6 +165,8 @@ func InitState(key string, value interface{}) Option {
 		return InitState(key, old)
 	}
 }
+
+// {{ end }} ==template==
 
 // ParseFile parses the file identified by filename.
 func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
@@ -216,10 +220,14 @@ type current struct {
 	pos  position // start position of the match
 	text []byte   // raw text of the match
 
+	// ==template== {{ if or .GlobalState (not .Optimize) }}
+
 	// state is a store for arbitrary key,value pairs that the user wants to be
 	// tied to the backtracking of the parser.
 	// This is always rolled back if a parsing rule fails.
 	state storeDict
+
+	// {{ end }} ==template==
 
 	// globalStore is a general store for the user to store arbitrary key-value
 	// pairs that they need to manage and that they do not want tied to the
@@ -295,10 +303,14 @@ type ruleRefExpr struct {
 	name string
 }
 
+// ==template== {{ if or .GlobalState (not .Optimize) }}
+
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
+
+// {{ end }} ==template==
 
 type andCodeExpr struct {
 	pos position
@@ -402,7 +414,9 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		pt:       savepoint{position: position{line: 1}},
 		recover:  true,
 		cur: current{
-			state:       make(storeDict),
+			// ==template== {{ if or .GlobalState (not .Optimize) }}
+			state: make(storeDict),
+			// {{ end }} ==template==
 			globalStore: make(storeDict),
 		},
 		maxFailPos:      position{col: 1, line: 1},
@@ -410,7 +424,9 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		// ==template== {{ if or .GlobalState (not .Optimize) }}
 		emptyState: make(storeDict),
+		// {{ end }} ==template==
 	}
 	p.setOptions(opts)
 
@@ -665,6 +681,8 @@ func (p *parser) restore(pt savepoint) {
 	p.pt = pt
 }
 
+// ==template== {{ if or .GlobalState (not .Optimize) }}
+
 // Cloner is implemented by any value that has a Clone method, which returns a
 // copy of the value. This is mainly used for types which are not passed by
 // value (e.g map, slice, chan) or structs that contain such types.
@@ -712,6 +730,8 @@ func (p *parser) restoreState(state storeDict) {
 	// {{ end }} ==template==
 	p.cur.state = state
 }
+
+// {{ end }} ==template==
 
 // get the slice of bytes from the savepoint start to the current position.
 func (p *parser) sliceFrom(start savepoint) []byte {
@@ -915,8 +935,10 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		val, ok = p.parseRuleRefExpr(expr)
 	case *seqExpr:
 		val, ok = p.parseSeqExpr(expr)
+	// ==template== {{ if or .GlobalState (not .Optimize) }}
 	case *stateCodeExpr:
 		val, ok = p.parseStateCodeExpr(expr)
+	// {{ end }} ==template==
 	case *throwExpr:
 		val, ok = p.parseThrowExpr(expr)
 	case *zeroOrMoreExpr:
@@ -946,14 +968,14 @@ func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
 	if ok {
 		p.cur.pos = start.position
 		p.cur.text = p.sliceFrom(start)
-		// ==template== {{ if not .Optimize }}
+		// ==template== {{ if or .GlobalState (not .Optimize) }}
 		state := p.cloneState()
 		// {{ end }} ==template==
 		actVal, err := act.run(p)
 		if err != nil {
 			p.addErrAt(err, start.position, []string{})
 		}
-		// ==template== {{ if not .Optimize }}
+		// ==template== {{ if or .GlobalState (not .Optimize) }}
 		p.restoreState(state)
 		// {{ end }} ==template==
 
@@ -973,14 +995,16 @@ func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
 		defer p.out(p.in("parseAndCodeExpr"))
 	}
 
-	state := p.cloneState()
-
 	// {{ end }} ==template==
+	// ==template== {{ if or .GlobalState (not .Optimize) }}
+	state := p.cloneState()
+	// {{ end }} ==template==
+
 	ok, err := and.run(p)
 	if err != nil {
 		p.addErr(err)
 	}
-	// ==template== {{ if not .Optimize }}
+	// ==template== {{ if or .GlobalState (not .Optimize) }}
 	p.restoreState(state)
 	// {{ end }} ==template==
 
@@ -1130,7 +1154,10 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		// dummy assignment to prevent compile error if optimized
 		_ = altI
 
+		// ==template== {{ if or .GlobalState (not .Optimize) }}
 		state := p.cloneState()
+		// {{ end }} ==template==
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
@@ -1140,7 +1167,9 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 			// {{ end }} ==template==
 			return val, ok
 		}
+		// ==template== {{ if or .GlobalState (not .Optimize) }}
 		p.restoreState(state)
+		// {{ end }} ==template==
 	}
 	// ==template== {{ if not .Optimize }}
 	p.incChoiceAltCnt(ch, choiceNoMatch)
@@ -1200,6 +1229,8 @@ func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
 		defer p.out(p.in("parseNotCodeExpr"))
 	}
 
+	// {{ end }} ==template==
+	// ==template== {{ if or .GlobalState (not .Optimize) }}
 	state := p.cloneState()
 
 	// {{ end }} ==template==
@@ -1207,7 +1238,7 @@ func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
 	if err != nil {
 		p.addErr(err)
 	}
-	// ==template== {{ if not .Optimize }}
+	// ==template== {{ if or .GlobalState (not .Optimize) }}
 	p.restoreState(state)
 	// {{ end }} ==template==
 
@@ -1310,19 +1341,21 @@ func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
 	return vals, true
 }
 
+// ==template== {{ if or .GlobalState (not .Optimize) }}
+
 func (p *parser) parseStateCodeExpr(state *stateCodeExpr) (interface{}, bool) {
-	// ==template== {{ if not .Optimize }}
 	if p.debug {
 		defer p.out(p.in("parseStateCodeExpr"))
 	}
 
-	// {{ end }} ==template==
 	err := state.run(p)
 	if err != nil {
 		p.addErr(err)
 	}
 	return nil, true
 }
+
+// {{ end }} ==template==
 
 func (p *parser) parseThrowExpr(expr *throwExpr) (interface{}, bool) {
 	// ==template== {{ if not .Optimize }}

--- a/doc.go
+++ b/doc.go
@@ -65,9 +65,11 @@ The following options can be specified:
 	optimization potential of the grammar.
 
 	-optimize-parser : boolean, if set, the options Debug, Memoize and Statistics are
-	removed	from the resulting parser as well as the restoration of the global "state"
-	store after action and predicate code blocks. This saves a few cpu cycles, when
-	using the generated parser (default: false).
+	removed	from the resulting parser. The global "state" is optimized as well by
+	either removing all related code if no state change expression is present in the
+	grammar or by removing the restoration of the global "state" store after action
+	and predicate code blocks. This saves a few cpu cycles, when using the generated
+	parser (default: false).
 
 	-x : boolean, if set, do not build the parser, just parse the input grammar
 	(default: false).
@@ -302,7 +304,7 @@ Predicate code blocks are code blocks declared immediately after the and "&"
 or the not "!" operators. Like action code blocks, predicate code blocks
 are turned into a method on the "*current" type in the generated source code.
 The method receives any labeled expression's value as argument (as interface{})
-and must return two values, the first being a bool and the second an error.
+and must return two opt, the first being a bool and the second an error.
 If a non-nil error is returned, it is added to the list of errors that the
 parser will return. E.g.:
 	RuleAB = [ab]i+ &{

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -1509,6 +1509,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/examples/indentation/indentation.go
+++ b/examples/indentation/indentation.go
@@ -1816,6 +1816,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -1803,6 +1803,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -1974,6 +1974,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -837,16 +837,6 @@ func GlobalStore(key string, value interface{}) Option {
 	}
 }
 
-// InitState creates an Option to set a key to a certain value in
-// the global "state" store.
-func InitState(key string, value interface{}) Option {
-	return func(p *parser) Option {
-		old := p.cur.state[key]
-		p.cur.state[key] = value
-		return InitState(key, old)
-	}
-}
-
 // ParseFile parses the file identified by filename.
 func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 	f, err := os.Open(filename)
@@ -898,11 +888,6 @@ type savepoint struct {
 type current struct {
 	pos  position // start position of the match
 	text []byte   // raw text of the match
-
-	// state is a store for arbitrary key,value pairs that the user wants to be
-	// tied to the backtracking of the parser.
-	// This is always rolled back if a parsing rule fails.
-	state storeDict
 
 	// globalStore is a general store for the user to store arbitrary key-value
 	// pairs that they need to manage and that they do not want tied to the
@@ -976,11 +961,6 @@ type oneOrMoreExpr expr
 type ruleRefExpr struct {
 	pos  position
 	name string
-}
-
-type stateCodeExpr struct {
-	pos position
-	run func(*parser) error
 }
 
 type andCodeExpr struct {
@@ -1085,7 +1065,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		pt:       savepoint{position: position{line: 1}},
 		recover:  true,
 		cur: current{
-			state:       make(storeDict),
 			globalStore: make(storeDict),
 		},
 		maxFailPos:      position{col: 1, line: 1},
@@ -1093,7 +1072,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1312,44 +1290,6 @@ func (p *parser) restore(pt savepoint) {
 	p.pt = pt
 }
 
-// Cloner is implemented by any value that has a Clone method, which returns a
-// copy of the value. This is mainly used for types which are not passed by
-// value (e.g map, slice, chan) or structs that contain such types.
-//
-// This is used in conjunction with the global state feature to create proper
-// copies of the state to allow the parser to properly restore the state in
-// the case of backtracking.
-type Cloner interface {
-	Clone() interface{}
-}
-
-// clone and return parser current state.
-func (p *parser) cloneState() storeDict {
-
-	if len(p.cur.state) == 0 {
-		if len(p.emptyState) > 0 {
-			p.emptyState = make(storeDict)
-		}
-		return p.emptyState
-	}
-
-	state := make(storeDict, len(p.cur.state))
-	for k, v := range p.cur.state {
-		if c, ok := v.(Cloner); ok {
-			state[k] = c.Clone()
-		} else {
-			state[k] = v
-		}
-	}
-	return state
-}
-
-// restore parser current state to the state storeDict.
-// every restoreState should applied only one time for every cloned state
-func (p *parser) restoreState(state storeDict) {
-	p.cur.state = state
-}
-
 // get the slice of bytes from the savepoint start to the current position.
 func (p *parser) sliceFrom(start savepoint) []byte {
 	return p.data[start.position.offset:p.pt.position.offset]
@@ -1483,8 +1423,6 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		val, ok = p.parseRuleRefExpr(expr)
 	case *seqExpr:
 		val, ok = p.parseSeqExpr(expr)
-	case *stateCodeExpr:
-		val, ok = p.parseStateCodeExpr(expr)
 	case *throwExpr:
 		val, ok = p.parseThrowExpr(expr)
 	case *zeroOrMoreExpr:
@@ -1514,6 +1452,7 @@ func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
+
 	ok, err := and.run(p)
 	if err != nil {
 		p.addErr(err)
@@ -1620,14 +1559,12 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		// dummy assignment to prevent compile error if optimized
 		_ = altI
 
-		state := p.cloneState()
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
 			return val, ok
 		}
-		p.restoreState(state)
 	}
 	return nil, false
 }
@@ -1739,14 +1676,6 @@ func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
 		vals = append(vals, val)
 	}
 	return vals, true
-}
-
-func (p *parser) parseStateCodeExpr(state *stateCodeExpr) (interface{}, bool) {
-	err := state.run(p)
-	if err != nil {
-		p.addErr(err)
-	}
-	return nil, true
 }
 
 func (p *parser) parseThrowExpr(expr *throwExpr) (interface{}, bool) {

--- a/pigeon.go
+++ b/pigeon.go
@@ -4167,6 +4167,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -1278,6 +1278,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -1224,6 +1224,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/emptystate/emptystate.go
+++ b/test/emptystate/emptystate.go
@@ -1279,6 +1279,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -1639,6 +1639,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -1242,6 +1242,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -1459,6 +1459,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/goto_state/goto_state.go
+++ b/test/goto_state/goto_state.go
@@ -1487,6 +1487,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -1163,6 +1163,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -1181,6 +1181,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -1401,6 +1401,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -1256,6 +1256,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -1091,6 +1091,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -1307,6 +1307,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -1153,6 +1153,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -1233,6 +1233,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/stateclone/stateclone.go
+++ b/test/stateclone/stateclone.go
@@ -1319,6 +1319,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/statereadonly/statereadonly.go
+++ b/test/statereadonly/statereadonly.go
@@ -1300,6 +1300,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -2186,6 +2186,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		_ = altI
 
 		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()


### PR DESCRIPTION
@mna I quickly put together the idea of optimizing the global state handling by removing all the not necessary code, if the state change expression is not used by a generated parser, as suggested by you in https://github.com/mna/pigeon/pull/52#issuecomment-340593754.

What do you think?