### PR TITLE
Remove emptyState optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,9 @@ $(TEST_DIR)/stateclone/stateclone.go: $(TEST_DIR)/stateclone/stateclone.peg $(BI
 $(TEST_DIR)/statereadonly/statereadonly.go: $(TEST_DIR)/statereadonly/statereadonly.peg $(BINDIR)/pigeon
 	$(BINDIR)/pigeon $< > $@
 
+$(TEST_DIR)/emptystate/emptystate.go: $(TEST_DIR)/emptystate/emptystate.peg $(BINDIR)/pigeon
+	$(BINDIR)/pigeon $< > $@
+
 lint:
 	golint ./...
 	go vet ./...

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2571,6 +2571,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -2659,6 +2660,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -2831,6 +2835,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2571,7 +2571,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -2660,9 +2659,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -2835,12 +2831,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2571,7 +2571,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -2662,7 +2662,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -2836,9 +2836,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2571,7 +2571,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -2662,7 +2662,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -2836,11 +2836,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -410,6 +410,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -500,6 +501,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -679,6 +683,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 	// {{ end }} ==template==
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -410,7 +410,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -501,9 +500,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -683,12 +679,6 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 	// {{ end }} ==template==
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -410,7 +410,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -503,7 +503,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -684,11 +684,12 @@ func (p *parser) cloneState() storeDict {
 	}
 	// {{ end }} ==template==
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -410,7 +410,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -503,7 +503,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -684,9 +684,11 @@ func (p *parser) cloneState() storeDict {
 	}
 	// {{ end }} ==template==
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -426,6 +426,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -516,6 +517,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -695,6 +699,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 	// {{ end }} ==template==
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -426,7 +426,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -519,7 +519,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -700,9 +700,11 @@ func (p *parser) cloneState() storeDict {
 	}
 	// {{ end }} ==template==
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -426,7 +426,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -519,7 +519,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -700,11 +700,12 @@ func (p *parser) cloneState() storeDict {
 	}
 	// {{ end }} ==template==
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -426,7 +426,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -517,9 +516,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -699,12 +695,6 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 	// {{ end }} ==template==
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -849,6 +849,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -937,6 +938,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1109,6 +1113,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -849,7 +849,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -938,9 +937,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1113,12 +1109,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -849,7 +849,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -940,7 +940,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1114,11 +1114,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -849,7 +849,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -940,7 +940,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1114,9 +1114,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/indentation/indentation.go
+++ b/examples/indentation/indentation.go
@@ -1156,7 +1156,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1245,9 +1244,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1420,12 +1416,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/indentation/indentation.go
+++ b/examples/indentation/indentation.go
@@ -1156,6 +1156,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1244,6 +1245,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1416,6 +1420,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/indentation/indentation.go
+++ b/examples/indentation/indentation.go
@@ -1156,7 +1156,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1247,7 +1247,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1421,11 +1421,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/indentation/indentation.go
+++ b/examples/indentation/indentation.go
@@ -1156,7 +1156,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1247,7 +1247,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1421,9 +1421,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -1143,6 +1143,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1231,6 +1232,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1403,6 +1407,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -1143,7 +1143,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1234,7 +1234,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1408,11 +1408,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -1143,7 +1143,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1234,7 +1234,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1408,9 +1408,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -1143,7 +1143,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1232,9 +1231,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1407,12 +1403,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -1314,7 +1314,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1405,7 +1405,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1579,9 +1579,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -1314,7 +1314,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1403,9 +1402,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1578,12 +1574,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -1314,6 +1314,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1402,6 +1403,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1574,6 +1578,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -1314,7 +1314,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1405,7 +1405,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1579,11 +1579,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -1093,6 +1093,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1175,6 +1176,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1321,6 +1325,12 @@ type Cloner interface {
 
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -1093,7 +1093,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1178,7 +1178,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1326,9 +1326,11 @@ type Cloner interface {
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -1093,7 +1093,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1178,7 +1178,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1326,11 +1326,12 @@ type Cloner interface {
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -1093,7 +1093,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1176,9 +1175,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1325,12 +1321,6 @@ type Cloner interface {
 
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/pigeon.go
+++ b/pigeon.go
@@ -3507,7 +3507,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -3598,7 +3598,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -3772,11 +3772,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/pigeon.go
+++ b/pigeon.go
@@ -3507,6 +3507,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -3595,6 +3596,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -3767,6 +3771,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/pigeon.go
+++ b/pigeon.go
@@ -3507,7 +3507,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -3598,7 +3598,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -3772,9 +3772,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/pigeon.go
+++ b/pigeon.go
@@ -3507,7 +3507,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -3596,9 +3595,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -3771,12 +3767,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -618,6 +618,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -706,6 +707,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -878,6 +882,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -618,7 +618,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -709,7 +709,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -883,9 +883,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -618,7 +618,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -707,9 +706,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -882,12 +878,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -618,7 +618,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -709,7 +709,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -883,11 +883,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -564,7 +564,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -655,7 +655,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -829,9 +829,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -564,7 +564,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -653,9 +652,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -828,12 +824,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -564,6 +564,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -652,6 +653,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -824,6 +828,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -564,7 +564,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -655,7 +655,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -829,11 +829,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/emptystate/emptystate.go
+++ b/test/emptystate/emptystate.go
@@ -619,7 +619,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -710,7 +710,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -884,9 +884,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/emptystate/emptystate.go
+++ b/test/emptystate/emptystate.go
@@ -619,6 +619,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -707,6 +708,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -879,6 +883,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/emptystate/emptystate.go
+++ b/test/emptystate/emptystate.go
@@ -619,7 +619,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -710,7 +710,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -884,11 +884,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/emptystate/emptystate.go
+++ b/test/emptystate/emptystate.go
@@ -619,7 +619,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -708,9 +707,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -883,12 +879,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/emptystate/emptystate.go
+++ b/test/emptystate/emptystate.go
@@ -1,0 +1,1491 @@
+package emptystate
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+var g = &grammar{
+	rules: []*rule{
+		{
+			name: "start",
+			pos:  position{line: 5, col: 1, offset: 26},
+			expr: &actionExpr{
+				pos: position{line: 5, col: 10, offset: 35},
+				run: (*parser).callonstart1,
+				expr: &seqExpr{
+					pos: position{line: 5, col: 10, offset: 35},
+					exprs: []interface{}{
+						&stateCodeExpr{
+							pos: position{line: 5, col: 10, offset: 35},
+							run: (*parser).callonstart3,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 5, col: 26, offset: 51},
+							name: "a",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 5, col: 28, offset: 53},
+							name: "b",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 5, col: 30, offset: 55},
+							name: "c",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 5, col: 32, offset: 57},
+							name: "d",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 5, col: 34, offset: 59},
+							name: "e",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "a",
+			pos:  position{line: 10, col: 1, offset: 94},
+			expr: &actionExpr{
+				pos: position{line: 10, col: 6, offset: 99},
+				run: (*parser).callona1,
+				expr: &litMatcher{
+					pos:        position{line: 10, col: 6, offset: 99},
+					val:        "a",
+					ignoreCase: false,
+				},
+			},
+		},
+		{
+			name: "b",
+			pos:  position{line: 16, col: 1, offset: 224},
+			expr: &seqExpr{
+				pos: position{line: 16, col: 6, offset: 229},
+				exprs: []interface{}{
+					&litMatcher{
+						pos:        position{line: 16, col: 6, offset: 229},
+						val:        "b",
+						ignoreCase: false,
+					},
+					&stateCodeExpr{
+						pos: position{line: 17, col: 3, offset: 235},
+						run: (*parser).callonb3,
+					},
+				},
+			},
+		},
+		{
+			name: "c",
+			pos:  position{line: 23, col: 1, offset: 337},
+			expr: &actionExpr{
+				pos: position{line: 23, col: 6, offset: 342},
+				run: (*parser).callonc1,
+				expr: &litMatcher{
+					pos:        position{line: 23, col: 6, offset: 342},
+					val:        "c",
+					ignoreCase: false,
+				},
+			},
+		},
+		{
+			name: "d",
+			pos:  position{line: 29, col: 1, offset: 484},
+			expr: &seqExpr{
+				pos: position{line: 29, col: 6, offset: 489},
+				exprs: []interface{}{
+					&litMatcher{
+						pos:        position{line: 29, col: 6, offset: 489},
+						val:        "d",
+						ignoreCase: false,
+					},
+					&stateCodeExpr{
+						pos: position{line: 30, col: 3, offset: 495},
+						run: (*parser).callond3,
+					},
+				},
+			},
+		},
+		{
+			name: "e",
+			pos:  position{line: 36, col: 1, offset: 647},
+			expr: &actionExpr{
+				pos: position{line: 36, col: 6, offset: 652},
+				run: (*parser).callone1,
+				expr: &litMatcher{
+					pos:        position{line: 36, col: 6, offset: 652},
+					val:        "e",
+					ignoreCase: false,
+				},
+			},
+		},
+	},
+}
+
+func (c *current) onstart3() error {
+	return nil
+}
+
+func (p *parser) callonstart3() error {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onstart3()
+}
+
+func (c *current) onstart1() (interface{}, error) {
+	return c.state, nil
+
+}
+
+func (p *parser) callonstart1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onstart1()
+}
+
+func (c *current) ona1() (interface{}, error) {
+	// action code block forces the clone/restore of state, so p.cur.state === p.emptyState
+	return nil, nil
+
+}
+
+func (p *parser) callona1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.ona1()
+}
+
+func (c *current) onb3() error {
+	// set thing in state, emptyState no longer empty
+	c.state["thing"] = 1
+	return nil
+
+}
+
+func (p *parser) callonb3() error {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onb3()
+}
+
+func (c *current) onc1() (interface{}, error) {
+	// code block forces clone/restore of state, so p.cur.state !== p.emptyState, but both are now non-empty
+	return nil, nil
+
+}
+
+func (p *parser) callonc1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onc1()
+}
+
+func (c *current) ond3() error {
+	// remove the thing from the state, so it is now empty in p.cur.state (but not in p.emptyState)
+	delete(c.state, "thing")
+	return nil
+
+}
+
+func (p *parser) callond3() error {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.ond3()
+}
+
+func (c *current) one1() (interface{}, error) {
+	// code block forces a clone, but c.state is empty so it returns p.emptyState, and then on restore
+	// c.state is set to that p.emptyState, which is not empty.
+	return nil, nil
+
+}
+
+func (p *parser) callone1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.one1()
+}
+
+var (
+	// errNoRule is returned when the grammar to parse has no rule.
+	errNoRule = errors.New("grammar has no rule")
+
+	// errInvalidEntrypoint is returned when the specified entrypoint rule
+	// does not exit.
+	errInvalidEntrypoint = errors.New("invalid entrypoint")
+
+	// errInvalidEncoding is returned when the source is not properly
+	// utf8-encoded.
+	errInvalidEncoding = errors.New("invalid encoding")
+
+	// errMaxExprCnt is used to signal that the maximum number of
+	// expressions have been parsed.
+	errMaxExprCnt = errors.New("max number of expresssions parsed")
+)
+
+// Option is a function that can set an option on the parser. It returns
+// the previous setting as an Option.
+type Option func(*parser) Option
+
+// MaxExpressions creates an Option to stop parsing after the provided
+// number of expressions have been parsed, if the value is 0 then the parser will
+// parse for as many steps as needed (possibly an infinite number).
+//
+// The default for maxExprCnt is 0.
+func MaxExpressions(maxExprCnt uint64) Option {
+	return func(p *parser) Option {
+		oldMaxExprCnt := p.maxExprCnt
+		p.maxExprCnt = maxExprCnt
+		return MaxExpressions(oldMaxExprCnt)
+	}
+}
+
+// Entrypoint creates an Option to set the rule name to use as entrypoint.
+// The rule name must have been specified in the -alternate-entrypoints
+// if generating the parser with the -optimize-grammar flag, otherwise
+// it may have been optimized out. Passing an empty string sets the
+// entrypoint to the first rule in the grammar.
+//
+// The default is to start parsing at the first rule in the grammar.
+func Entrypoint(ruleName string) Option {
+	return func(p *parser) Option {
+		oldEntrypoint := p.entrypoint
+		p.entrypoint = ruleName
+		if ruleName == "" {
+			p.entrypoint = g.rules[0].name
+		}
+		return Entrypoint(oldEntrypoint)
+	}
+}
+
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+// Also the key for the "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
+	return func(p *parser) Option {
+		oldStats := p.Stats
+		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(oldStats, oldChoiceNoMatch)
+	}
+}
+
+// Debug creates an Option to set the debug flag to b. When set to true,
+// debugging information is printed to stdout while parsing.
+//
+// The default is false.
+func Debug(b bool) Option {
+	return func(p *parser) Option {
+		old := p.debug
+		p.debug = b
+		return Debug(old)
+	}
+}
+
+// Memoize creates an Option to set the memoize flag to b. When set to true,
+// the parser will cache all results so each expression is evaluated only
+// once. This guarantees linear parsing time even for pathological cases,
+// at the expense of more memory and slower times for typical cases.
+//
+// The default is false.
+func Memoize(b bool) Option {
+	return func(p *parser) Option {
+		old := p.memoize
+		p.memoize = b
+		return Memoize(old)
+	}
+}
+
+// AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
+// Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
+// by character class matchers and is matched by the any matcher.
+// The returned matched value, c.text and c.offset are NOT affected.
+//
+// The default is false.
+func AllowInvalidUTF8(b bool) Option {
+	return func(p *parser) Option {
+		old := p.allowInvalidUTF8
+		p.allowInvalidUTF8 = b
+		return AllowInvalidUTF8(old)
+	}
+}
+
+// Recover creates an Option to set the recover flag to b. When set to
+// true, this causes the parser to recover from panics and convert it
+// to an error. Setting it to false can be useful while debugging to
+// access the full stack trace.
+//
+// The default is true.
+func Recover(b bool) Option {
+	return func(p *parser) Option {
+		old := p.recover
+		p.recover = b
+		return Recover(old)
+	}
+}
+
+// GlobalStore creates an Option to set a key to a certain value in
+// the globalStore.
+func GlobalStore(key string, value interface{}) Option {
+	return func(p *parser) Option {
+		old := p.cur.globalStore[key]
+		p.cur.globalStore[key] = value
+		return GlobalStore(key, old)
+	}
+}
+
+// InitState creates an Option to set a key to a certain value in
+// the global "state" store.
+func InitState(key string, value interface{}) Option {
+	return func(p *parser) Option {
+		old := p.cur.state[key]
+		p.cur.state[key] = value
+		return InitState(key, old)
+	}
+}
+
+// ParseFile parses the file identified by filename.
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			err = closeErr
+		}
+	}()
+	return ParseReader(filename, f, opts...)
+}
+
+// ParseReader parses the data from r using filename as information in the
+// error messages.
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return Parse(filename, b, opts...)
+}
+
+// Parse parses the data from b using filename as information in the
+// error messages.
+func Parse(filename string, b []byte, opts ...Option) (interface{}, error) {
+	return newParser(filename, b, opts...).parse(g)
+}
+
+// position records a position in the text.
+type position struct {
+	line, col, offset int
+}
+
+func (p position) String() string {
+	return fmt.Sprintf("%d:%d [%d]", p.line, p.col, p.offset)
+}
+
+// savepoint stores all state required to go back to this point in the
+// parser.
+type savepoint struct {
+	position
+	rn rune
+	w  int
+}
+
+type current struct {
+	pos  position // start position of the match
+	text []byte   // raw text of the match
+
+	// state is a store for arbitrary key,value pairs that the user wants to be
+	// tied to the backtracking of the parser.
+	// This is always rolled back if a parsing rule fails.
+	state storeDict
+
+	// globalStore is a general store for the user to store arbitrary key-value
+	// pairs that they need to manage and that they do not want tied to the
+	// backtracking of the parser. This is only modified by the user and never
+	// rolled back by the parser. It is always up to the user to keep this in a
+	// consistent state.
+	globalStore storeDict
+}
+
+type storeDict map[string]interface{}
+
+// the AST types...
+
+type grammar struct {
+	pos   position
+	rules []*rule
+}
+
+type rule struct {
+	pos         position
+	name        string
+	displayName string
+	expr        interface{}
+}
+
+type choiceExpr struct {
+	pos          position
+	alternatives []interface{}
+}
+
+type actionExpr struct {
+	pos  position
+	expr interface{}
+	run  func(*parser) (interface{}, error)
+}
+
+type recoveryExpr struct {
+	pos          position
+	expr         interface{}
+	recoverExpr  interface{}
+	failureLabel []string
+}
+
+type seqExpr struct {
+	pos   position
+	exprs []interface{}
+}
+
+type throwExpr struct {
+	pos   position
+	label string
+}
+
+type labeledExpr struct {
+	pos   position
+	label string
+	expr  interface{}
+}
+
+type expr struct {
+	pos  position
+	expr interface{}
+}
+
+type andExpr expr
+type notExpr expr
+type zeroOrOneExpr expr
+type zeroOrMoreExpr expr
+type oneOrMoreExpr expr
+
+type ruleRefExpr struct {
+	pos  position
+	name string
+}
+
+type stateCodeExpr struct {
+	pos position
+	run func(*parser) error
+}
+
+type andCodeExpr struct {
+	pos position
+	run func(*parser) (bool, error)
+}
+
+type notCodeExpr struct {
+	pos position
+	run func(*parser) (bool, error)
+}
+
+type litMatcher struct {
+	pos        position
+	val        string
+	ignoreCase bool
+}
+
+type charClassMatcher struct {
+	pos             position
+	val             string
+	basicLatinChars [128]bool
+	chars           []rune
+	ranges          []rune
+	classes         []*unicode.RangeTable
+	ignoreCase      bool
+	inverted        bool
+}
+
+type anyMatcher position
+
+// errList cumulates the errors found by the parser.
+type errList []error
+
+func (e *errList) add(err error) {
+	*e = append(*e, err)
+}
+
+func (e errList) err() error {
+	if len(e) == 0 {
+		return nil
+	}
+	e.dedupe()
+	return e
+}
+
+func (e *errList) dedupe() {
+	var cleaned []error
+	set := make(map[string]bool)
+	for _, err := range *e {
+		if msg := err.Error(); !set[msg] {
+			set[msg] = true
+			cleaned = append(cleaned, err)
+		}
+	}
+	*e = cleaned
+}
+
+func (e errList) Error() string {
+	switch len(e) {
+	case 0:
+		return ""
+	case 1:
+		return e[0].Error()
+	default:
+		var buf bytes.Buffer
+
+		for i, err := range e {
+			if i > 0 {
+				buf.WriteRune('\n')
+			}
+			buf.WriteString(err.Error())
+		}
+		return buf.String()
+	}
+}
+
+// parserError wraps an error with a prefix indicating the rule in which
+// the error occurred. The original error is stored in the Inner field.
+type parserError struct {
+	Inner    error
+	pos      position
+	prefix   string
+	expected []string
+}
+
+// Error returns the error message.
+func (p *parserError) Error() string {
+	return p.prefix + ": " + p.Inner.Error()
+}
+
+// newParser creates a parser with the specified input source and options.
+func newParser(filename string, b []byte, opts ...Option) *parser {
+	stats := Stats{
+		ChoiceAltCnt: make(map[string]map[string]int),
+	}
+
+	p := &parser{
+		filename: filename,
+		errs:     new(errList),
+		data:     b,
+		pt:       savepoint{position: position{line: 1}},
+		recover:  true,
+		cur: current{
+			state:       make(storeDict),
+			globalStore: make(storeDict),
+		},
+		maxFailPos:      position{col: 1, line: 1},
+		maxFailExpected: make([]string, 0, 20),
+		Stats:           &stats,
+		// start rule is rule [0] unless an alternate entrypoint is specified
+		entrypoint: g.rules[0].name,
+		emptyState: make(storeDict),
+	}
+	p.setOptions(opts)
+
+	if p.maxExprCnt == 0 {
+		p.maxExprCnt = math.MaxUint64
+	}
+
+	return p
+}
+
+// setOptions applies the options to the parser.
+func (p *parser) setOptions(opts []Option) {
+	for _, opt := range opts {
+		opt(p)
+	}
+}
+
+type resultTuple struct {
+	v   interface{}
+	b   bool
+	end savepoint
+}
+
+const choiceNoMatch = -1
+
+// Stats stores some statistics, gathered during parsing
+type Stats struct {
+	// ExprCnt counts the number of expressions processed during parsing
+	// This value is compared to the maximum number of expressions allowed
+	// (set by the MaxExpressions option).
+	ExprCnt uint64
+
+	// ChoiceAltCnt is used to count for each ordered choice expression,
+	// which alternative is used how may times.
+	// These numbers allow to optimize the order of the ordered choice expression
+	// to increase the performance of the parser
+	//
+	// The outer key of ChoiceAltCnt is composed of the name of the rule as well
+	// as the line and the column of the ordered choice.
+	// The inner key of ChoiceAltCnt is the number (one-based) of the matching alternative.
+	// For each alternative the number of matches are counted. If an ordered choice does not
+	// match, a special counter is incremented. The name of this counter is set with
+	// the parser option Statistics.
+	// For an alternative to be included in ChoiceAltCnt, it has to match at least once.
+	ChoiceAltCnt map[string]map[string]int
+}
+
+type parser struct {
+	filename string
+	pt       savepoint
+	cur      current
+
+	data []byte
+	errs *errList
+
+	depth   int
+	recover bool
+	debug   bool
+
+	memoize bool
+	// memoization table for the packrat algorithm:
+	// map[offset in source] map[expression or rule] {value, match}
+	memo map[int]map[interface{}]resultTuple
+
+	// rules table, maps the rule identifier to the rule node
+	rules map[string]*rule
+	// variables stack, map of label to value
+	vstack []map[string]interface{}
+	// rule stack, allows identification of the current rule in errors
+	rstack []*rule
+
+	// parse fail
+	maxFailPos            position
+	maxFailExpected       []string
+	maxFailInvertExpected bool
+
+	// max number of expressions to be parsed
+	maxExprCnt uint64
+	// entrypoint for the parser
+	entrypoint string
+
+	allowInvalidUTF8 bool
+
+	*Stats
+
+	choiceNoMatch string
+	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
+	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	emptyState storeDict
+}
+
+// push a variable set on the vstack.
+func (p *parser) pushV() {
+	if cap(p.vstack) == len(p.vstack) {
+		// create new empty slot in the stack
+		p.vstack = append(p.vstack, nil)
+	} else {
+		// slice to 1 more
+		p.vstack = p.vstack[:len(p.vstack)+1]
+	}
+
+	// get the last args set
+	m := p.vstack[len(p.vstack)-1]
+	if m != nil && len(m) == 0 {
+		// empty map, all good
+		return
+	}
+
+	m = make(map[string]interface{})
+	p.vstack[len(p.vstack)-1] = m
+}
+
+// pop a variable set from the vstack.
+func (p *parser) popV() {
+	// if the map is not empty, clear it
+	m := p.vstack[len(p.vstack)-1]
+	if len(m) > 0 {
+		// GC that map
+		p.vstack[len(p.vstack)-1] = nil
+	}
+	p.vstack = p.vstack[:len(p.vstack)-1]
+}
+
+// push a recovery expression with its labels to the recoveryStack
+func (p *parser) pushRecovery(labels []string, expr interface{}) {
+	if cap(p.recoveryStack) == len(p.recoveryStack) {
+		// create new empty slot in the stack
+		p.recoveryStack = append(p.recoveryStack, nil)
+	} else {
+		// slice to 1 more
+		p.recoveryStack = p.recoveryStack[:len(p.recoveryStack)+1]
+	}
+
+	m := make(map[string]interface{}, len(labels))
+	for _, fl := range labels {
+		m[fl] = expr
+	}
+	p.recoveryStack[len(p.recoveryStack)-1] = m
+}
+
+// pop a recovery expression from the recoveryStack
+func (p *parser) popRecovery() {
+	// GC that map
+	p.recoveryStack[len(p.recoveryStack)-1] = nil
+
+	p.recoveryStack = p.recoveryStack[:len(p.recoveryStack)-1]
+}
+
+func (p *parser) print(prefix, s string) string {
+	if !p.debug {
+		return s
+	}
+
+	fmt.Printf("%s %d:%d:%d: %s [%#U]\n",
+		prefix, p.pt.line, p.pt.col, p.pt.offset, s, p.pt.rn)
+	return s
+}
+
+func (p *parser) in(s string) string {
+	p.depth++
+	return p.print(strings.Repeat(" ", p.depth)+">", s)
+}
+
+func (p *parser) out(s string) string {
+	p.depth--
+	return p.print(strings.Repeat(" ", p.depth)+"<", s)
+}
+
+func (p *parser) addErr(err error) {
+	p.addErrAt(err, p.pt.position, []string{})
+}
+
+func (p *parser) addErrAt(err error, pos position, expected []string) {
+	var buf bytes.Buffer
+	if p.filename != "" {
+		buf.WriteString(p.filename)
+	}
+	if buf.Len() > 0 {
+		buf.WriteString(":")
+	}
+	buf.WriteString(fmt.Sprintf("%d:%d (%d)", pos.line, pos.col, pos.offset))
+	if len(p.rstack) > 0 {
+		if buf.Len() > 0 {
+			buf.WriteString(": ")
+		}
+		rule := p.rstack[len(p.rstack)-1]
+		if rule.displayName != "" {
+			buf.WriteString("rule " + rule.displayName)
+		} else {
+			buf.WriteString("rule " + rule.name)
+		}
+	}
+	pe := &parserError{Inner: err, pos: pos, prefix: buf.String(), expected: expected}
+	p.errs.add(pe)
+}
+
+func (p *parser) failAt(fail bool, pos position, want string) {
+	// process fail if parsing fails and not inverted or parsing succeeds and invert is set
+	if fail == p.maxFailInvertExpected {
+		if pos.offset < p.maxFailPos.offset {
+			return
+		}
+
+		if pos.offset > p.maxFailPos.offset {
+			p.maxFailPos = pos
+			p.maxFailExpected = p.maxFailExpected[:0]
+		}
+
+		if p.maxFailInvertExpected {
+			want = "!" + want
+		}
+		p.maxFailExpected = append(p.maxFailExpected, want)
+	}
+}
+
+// read advances the parser to the next rune.
+func (p *parser) read() {
+	p.pt.offset += p.pt.w
+	rn, n := utf8.DecodeRune(p.data[p.pt.offset:])
+	p.pt.rn = rn
+	p.pt.w = n
+	p.pt.col++
+	if rn == '\n' {
+		p.pt.line++
+		p.pt.col = 0
+	}
+
+	if rn == utf8.RuneError && n == 1 { // see utf8.DecodeRune
+		if !p.allowInvalidUTF8 {
+			p.addErr(errInvalidEncoding)
+		}
+	}
+}
+
+// restore parser position to the savepoint pt.
+func (p *parser) restore(pt savepoint) {
+	if p.debug {
+		defer p.out(p.in("restore"))
+	}
+	if pt.offset == p.pt.offset {
+		return
+	}
+	p.pt = pt
+}
+
+// Cloner is implemented by any value that has a Clone method, which returns a
+// copy of the value. This is mainly used for types which are not passed by
+// value (e.g map, slice, chan) or structs that contain such types.
+//
+// This is used in conjunction with the global state feature to create proper
+// copies of the state to allow the parser to properly restore the state in
+// the case of backtracking.
+type Cloner interface {
+	Clone() interface{}
+}
+
+// clone and return parser current state.
+func (p *parser) cloneState() storeDict {
+	if p.debug {
+		defer p.out(p.in("cloneState"))
+	}
+
+	if len(p.cur.state) == 0 {
+		return p.emptyState
+	}
+
+	state := make(storeDict, len(p.cur.state))
+	for k, v := range p.cur.state {
+		if c, ok := v.(Cloner); ok {
+			state[k] = c.Clone()
+		} else {
+			state[k] = v
+		}
+	}
+	return state
+}
+
+// restore parser current state to the state storeDict.
+// every restoreState should applied only one time for every cloned state
+func (p *parser) restoreState(state storeDict) {
+	if p.debug {
+		defer p.out(p.in("restoreState"))
+	}
+	p.cur.state = state
+}
+
+// get the slice of bytes from the savepoint start to the current position.
+func (p *parser) sliceFrom(start savepoint) []byte {
+	return p.data[start.position.offset:p.pt.position.offset]
+}
+
+func (p *parser) getMemoized(node interface{}) (resultTuple, bool) {
+	if len(p.memo) == 0 {
+		return resultTuple{}, false
+	}
+	m := p.memo[p.pt.offset]
+	if len(m) == 0 {
+		return resultTuple{}, false
+	}
+	res, ok := m[node]
+	return res, ok
+}
+
+func (p *parser) setMemoized(pt savepoint, node interface{}, tuple resultTuple) {
+	if p.memo == nil {
+		p.memo = make(map[int]map[interface{}]resultTuple)
+	}
+	m := p.memo[pt.offset]
+	if m == nil {
+		m = make(map[interface{}]resultTuple)
+		p.memo[pt.offset] = m
+	}
+	m[node] = tuple
+}
+
+func (p *parser) buildRulesTable(g *grammar) {
+	p.rules = make(map[string]*rule, len(g.rules))
+	for _, r := range g.rules {
+		p.rules[r.name] = r
+	}
+}
+
+func (p *parser) parse(g *grammar) (val interface{}, err error) {
+	if len(g.rules) == 0 {
+		p.addErr(errNoRule)
+		return nil, p.errs.err()
+	}
+
+	// TODO : not super critical but this could be generated
+	p.buildRulesTable(g)
+
+	if p.recover {
+		// panic can be used in action code to stop parsing immediately
+		// and return the panic as an error.
+		defer func() {
+			if e := recover(); e != nil {
+				if p.debug {
+					defer p.out(p.in("panic handler"))
+				}
+				val = nil
+				switch e := e.(type) {
+				case error:
+					p.addErr(e)
+				default:
+					p.addErr(fmt.Errorf("%v", e))
+				}
+				err = p.errs.err()
+			}
+		}()
+	}
+
+	startRule, ok := p.rules[p.entrypoint]
+	if !ok {
+		p.addErr(errInvalidEntrypoint)
+		return nil, p.errs.err()
+	}
+
+	p.read() // advance to first rune
+	val, ok = p.parseRule(startRule)
+	if !ok {
+		if len(*p.errs) == 0 {
+			// If parsing fails, but no errors have been recorded, the expected values
+			// for the farthest parser position are returned as error.
+			maxFailExpectedMap := make(map[string]struct{}, len(p.maxFailExpected))
+			for _, v := range p.maxFailExpected {
+				maxFailExpectedMap[v] = struct{}{}
+			}
+			expected := make([]string, 0, len(maxFailExpectedMap))
+			eof := false
+			if _, ok := maxFailExpectedMap["!."]; ok {
+				delete(maxFailExpectedMap, "!.")
+				eof = true
+			}
+			for k := range maxFailExpectedMap {
+				expected = append(expected, k)
+			}
+			sort.Strings(expected)
+			if eof {
+				expected = append(expected, "EOF")
+			}
+			p.addErrAt(errors.New("no match found, expected: "+listJoin(expected, ", ", "or")), p.maxFailPos, expected)
+		}
+
+		return nil, p.errs.err()
+	}
+	return val, p.errs.err()
+}
+
+func listJoin(list []string, sep string, lastSep string) string {
+	switch len(list) {
+	case 0:
+		return ""
+	case 1:
+		return list[0]
+	default:
+		return fmt.Sprintf("%s %s %s", strings.Join(list[:len(list)-1], sep), lastSep, list[len(list)-1])
+	}
+}
+
+func (p *parser) parseRule(rule *rule) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseRule " + rule.name))
+	}
+
+	if p.memoize {
+		res, ok := p.getMemoized(rule)
+		if ok {
+			p.restore(res.end)
+			return res.v, res.b
+		}
+	}
+
+	start := p.pt
+	p.rstack = append(p.rstack, rule)
+	p.pushV()
+	val, ok := p.parseExpr(rule.expr)
+	p.popV()
+	p.rstack = p.rstack[:len(p.rstack)-1]
+	if ok && p.debug {
+		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
+	}
+
+	if p.memoize {
+		p.setMemoized(start, rule, resultTuple{val, ok, p.pt})
+	}
+	return val, ok
+}
+
+func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
+	var pt savepoint
+
+	if p.memoize {
+		res, ok := p.getMemoized(expr)
+		if ok {
+			p.restore(res.end)
+			return res.v, res.b
+		}
+		pt = p.pt
+	}
+
+	p.ExprCnt++
+	if p.ExprCnt > p.maxExprCnt {
+		panic(errMaxExprCnt)
+	}
+
+	var val interface{}
+	var ok bool
+	switch expr := expr.(type) {
+	case *actionExpr:
+		val, ok = p.parseActionExpr(expr)
+	case *andCodeExpr:
+		val, ok = p.parseAndCodeExpr(expr)
+	case *andExpr:
+		val, ok = p.parseAndExpr(expr)
+	case *anyMatcher:
+		val, ok = p.parseAnyMatcher(expr)
+	case *charClassMatcher:
+		val, ok = p.parseCharClassMatcher(expr)
+	case *choiceExpr:
+		val, ok = p.parseChoiceExpr(expr)
+	case *labeledExpr:
+		val, ok = p.parseLabeledExpr(expr)
+	case *litMatcher:
+		val, ok = p.parseLitMatcher(expr)
+	case *notCodeExpr:
+		val, ok = p.parseNotCodeExpr(expr)
+	case *notExpr:
+		val, ok = p.parseNotExpr(expr)
+	case *oneOrMoreExpr:
+		val, ok = p.parseOneOrMoreExpr(expr)
+	case *recoveryExpr:
+		val, ok = p.parseRecoveryExpr(expr)
+	case *ruleRefExpr:
+		val, ok = p.parseRuleRefExpr(expr)
+	case *seqExpr:
+		val, ok = p.parseSeqExpr(expr)
+	case *stateCodeExpr:
+		val, ok = p.parseStateCodeExpr(expr)
+	case *throwExpr:
+		val, ok = p.parseThrowExpr(expr)
+	case *zeroOrMoreExpr:
+		val, ok = p.parseZeroOrMoreExpr(expr)
+	case *zeroOrOneExpr:
+		val, ok = p.parseZeroOrOneExpr(expr)
+	default:
+		panic(fmt.Sprintf("unknown expression type %T", expr))
+	}
+	if p.memoize {
+		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
+	}
+	return val, ok
+}
+
+func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseActionExpr"))
+	}
+
+	start := p.pt
+	val, ok := p.parseExpr(act.expr)
+	if ok {
+		p.cur.pos = start.position
+		p.cur.text = p.sliceFrom(start)
+		state := p.cloneState()
+		actVal, err := act.run(p)
+		if err != nil {
+			p.addErrAt(err, start.position, []string{})
+		}
+		p.restoreState(state)
+
+		val = actVal
+	}
+	if ok && p.debug {
+		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
+	}
+	return val, ok
+}
+
+func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseAndCodeExpr"))
+	}
+
+	state := p.cloneState()
+
+	ok, err := and.run(p)
+	if err != nil {
+		p.addErr(err)
+	}
+	p.restoreState(state)
+
+	return nil, ok
+}
+
+func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseAndExpr"))
+	}
+
+	pt := p.pt
+	p.pushV()
+	_, ok := p.parseExpr(and.expr)
+	p.popV()
+	p.restore(pt)
+	return nil, ok
+}
+
+func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseAnyMatcher"))
+	}
+
+	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
+		// EOF - see utf8.DecodeRune
+		p.failAt(false, p.pt.position, ".")
+		return nil, false
+	}
+	start := p.pt
+	p.read()
+	p.failAt(true, start.position, ".")
+	return p.sliceFrom(start), true
+}
+
+func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseCharClassMatcher"))
+	}
+
+	cur := p.pt.rn
+	start := p.pt
+
+	// can't match EOF
+	if cur == utf8.RuneError && p.pt.w == 0 { // see utf8.DecodeRune
+		p.failAt(false, start.position, chr.val)
+		return nil, false
+	}
+
+	if chr.ignoreCase {
+		cur = unicode.ToLower(cur)
+	}
+
+	// try to match in the list of available chars
+	for _, rn := range chr.chars {
+		if rn == cur {
+			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
+				return nil, false
+			}
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+	}
+
+	// try to match in the list of ranges
+	for i := 0; i < len(chr.ranges); i += 2 {
+		if cur >= chr.ranges[i] && cur <= chr.ranges[i+1] {
+			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
+				return nil, false
+			}
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+	}
+
+	// try to match in the list of Unicode classes
+	for _, cl := range chr.classes {
+		if unicode.Is(cl, cur) {
+			if chr.inverted {
+				p.failAt(false, start.position, chr.val)
+				return nil, false
+			}
+			p.read()
+			p.failAt(true, start.position, chr.val)
+			return p.sliceFrom(start), true
+		}
+	}
+
+	if chr.inverted {
+		p.read()
+		p.failAt(true, start.position, chr.val)
+		return p.sliceFrom(start), true
+	}
+	p.failAt(false, start.position, chr.val)
+	return nil, false
+}
+
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
+	}
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = p.choiceNoMatch
+	}
+	m[alt]++
+}
+
+func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseChoiceExpr"))
+	}
+
+	for altI, alt := range ch.alternatives {
+		// dummy assignment to prevent compile error if optimized
+		_ = altI
+
+		state := p.cloneState()
+		p.pushV()
+		val, ok := p.parseExpr(alt)
+		p.popV()
+		if ok {
+			p.incChoiceAltCnt(ch, altI)
+			return val, ok
+		}
+		p.restoreState(state)
+	}
+	p.incChoiceAltCnt(ch, choiceNoMatch)
+	return nil, false
+}
+
+func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseLabeledExpr"))
+	}
+
+	p.pushV()
+	val, ok := p.parseExpr(lab.expr)
+	p.popV()
+	if ok && lab.label != "" {
+		m := p.vstack[len(p.vstack)-1]
+		m[lab.label] = val
+	}
+	return val, ok
+}
+
+func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseLitMatcher"))
+	}
+
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
+	start := p.pt
+	for _, want := range lit.val {
+		cur := p.pt.rn
+		if lit.ignoreCase {
+			cur = unicode.ToLower(cur)
+		}
+		if cur != want {
+			p.failAt(false, start.position, val)
+			p.restore(start)
+			return nil, false
+		}
+		p.read()
+	}
+	p.failAt(true, start.position, val)
+	return p.sliceFrom(start), true
+}
+
+func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseNotCodeExpr"))
+	}
+
+	state := p.cloneState()
+
+	ok, err := not.run(p)
+	if err != nil {
+		p.addErr(err)
+	}
+	p.restoreState(state)
+
+	return nil, !ok
+}
+
+func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseNotExpr"))
+	}
+
+	pt := p.pt
+	p.pushV()
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
+	_, ok := p.parseExpr(not.expr)
+	p.maxFailInvertExpected = !p.maxFailInvertExpected
+	p.popV()
+	p.restore(pt)
+	return nil, !ok
+}
+
+func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseOneOrMoreExpr"))
+	}
+
+	var vals []interface{}
+
+	for {
+		p.pushV()
+		val, ok := p.parseExpr(expr.expr)
+		p.popV()
+		if !ok {
+			if len(vals) == 0 {
+				// did not match once, no match
+				return nil, false
+			}
+			return vals, true
+		}
+		vals = append(vals, val)
+	}
+}
+
+func (p *parser) parseRecoveryExpr(recover *recoveryExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseRecoveryExpr (" + strings.Join(recover.failureLabel, ",") + ")"))
+	}
+
+	p.pushRecovery(recover.failureLabel, recover.recoverExpr)
+	val, ok := p.parseExpr(recover.expr)
+	p.popRecovery()
+
+	return val, ok
+}
+
+func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseRuleRefExpr " + ref.name))
+	}
+
+	if ref.name == "" {
+		panic(fmt.Sprintf("%s: invalid rule: missing name", ref.pos))
+	}
+
+	rule := p.rules[ref.name]
+	if rule == nil {
+		p.addErr(fmt.Errorf("undefined rule: %s", ref.name))
+		return nil, false
+	}
+	return p.parseRule(rule)
+}
+
+func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseSeqExpr"))
+	}
+
+	vals := make([]interface{}, 0, len(seq.exprs))
+
+	pt := p.pt
+	for _, expr := range seq.exprs {
+		val, ok := p.parseExpr(expr)
+		if !ok {
+			p.restore(pt)
+			return nil, false
+		}
+		vals = append(vals, val)
+	}
+	return vals, true
+}
+
+func (p *parser) parseStateCodeExpr(state *stateCodeExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseStateCodeExpr"))
+	}
+
+	err := state.run(p)
+	if err != nil {
+		p.addErr(err)
+	}
+	return nil, true
+}
+
+func (p *parser) parseThrowExpr(expr *throwExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseThrowExpr"))
+	}
+
+	for i := len(p.recoveryStack) - 1; i >= 0; i-- {
+		if recoverExpr, ok := p.recoveryStack[i][expr.label]; ok {
+			if val, ok := p.parseExpr(recoverExpr); ok {
+				return val, ok
+			}
+		}
+	}
+
+	return nil, false
+}
+
+func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseZeroOrMoreExpr"))
+	}
+
+	var vals []interface{}
+
+	for {
+		p.pushV()
+		val, ok := p.parseExpr(expr.expr)
+		p.popV()
+		if !ok {
+			return vals, true
+		}
+		vals = append(vals, val)
+	}
+}
+
+func (p *parser) parseZeroOrOneExpr(expr *zeroOrOneExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseZeroOrOneExpr"))
+	}
+
+	p.pushV()
+	val, _ := p.parseExpr(expr.expr)
+	p.popV()
+	// whether it matched or not, consider it a match
+	return val, true
+}

--- a/test/emptystate/emptystate.peg
+++ b/test/emptystate/emptystate.peg
@@ -1,0 +1,42 @@
+{
+  package emptystate
+}
+
+start <- #{ return nil } a b c d e
+  {
+    return c.state, nil
+  }
+
+a <- 'a'
+  {
+    // action code block forces the clone/restore of state, so p.cur.state === p.emptyState
+    return nil, nil
+  }
+
+b <- 'b'
+  #{
+    // set thing in state, emptyState no longer empty
+    c.state["thing"] = 1
+    return nil
+  }
+
+c <- 'c'
+  {
+    // code block forces clone/restore of state, so p.cur.state !== p.emptyState, but both are now non-empty
+    return nil, nil
+  }
+
+d <- 'd'
+  #{
+    // remove the thing from the state, so it is now empty in p.cur.state (but not in p.emptyState)
+    delete(c.state, "thing")
+    return nil
+  }
+
+e <- 'e'
+  {
+    // code block forces a clone, but c.state is empty so it returns p.emptyState, and then on restore
+    // c.state is set to that p.emptyState, which is not empty.
+    return nil, nil
+  }
+

--- a/test/emptystate/emptystate_test.go
+++ b/test/emptystate/emptystate_test.go
@@ -1,0 +1,17 @@
+package emptystate
+
+import "testing"
+
+func TestEmptyState(t *testing.T) {
+	got, err := Parse("", []byte("abcde"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, ok := got.(storeDict)
+	if !ok {
+		t.Fatalf("expected map, got %T: %[1]v", got)
+	}
+	if len(state) != 0 {
+		t.Fatalf("want empty state, got %v", state)
+	}
+}

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -979,6 +979,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1067,6 +1068,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1239,6 +1243,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -979,7 +979,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1070,7 +1070,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1244,11 +1244,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -979,7 +979,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1068,9 +1067,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1243,12 +1239,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -979,7 +979,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1070,7 +1070,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1244,9 +1244,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -582,7 +582,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -673,7 +673,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -847,11 +847,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -582,6 +582,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -670,6 +671,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -842,6 +846,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -582,7 +582,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -671,9 +670,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -846,12 +842,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -582,7 +582,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -673,7 +673,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -847,9 +847,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -799,7 +799,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -890,7 +890,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1064,9 +1064,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -799,6 +799,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -887,6 +888,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1059,6 +1063,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -799,7 +799,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -888,9 +887,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1063,12 +1059,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -799,7 +799,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -890,7 +890,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1064,11 +1064,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/goto_state/goto_state.go
+++ b/test/goto_state/goto_state.go
@@ -827,7 +827,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -918,7 +918,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1092,9 +1092,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/goto_state/goto_state.go
+++ b/test/goto_state/goto_state.go
@@ -827,7 +827,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -918,7 +918,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1092,11 +1092,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/goto_state/goto_state.go
+++ b/test/goto_state/goto_state.go
@@ -827,6 +827,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -915,6 +916,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1087,6 +1091,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/goto_state/goto_state.go
+++ b/test/goto_state/goto_state.go
@@ -827,7 +827,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -916,9 +915,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1091,12 +1087,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -503,7 +503,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -592,9 +591,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -767,12 +763,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -503,7 +503,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -594,7 +594,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -768,9 +768,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -503,7 +503,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -594,7 +594,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -768,11 +768,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -503,6 +503,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -591,6 +592,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -763,6 +767,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -521,7 +521,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -610,9 +609,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -785,12 +781,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -521,7 +521,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -612,7 +612,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -786,9 +786,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -521,7 +521,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -612,7 +612,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -786,11 +786,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -521,6 +521,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -609,6 +610,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -781,6 +785,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -741,7 +741,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -830,9 +829,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1005,12 +1001,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -741,6 +741,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -829,6 +830,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1001,6 +1005,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -741,7 +741,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -832,7 +832,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1006,9 +1006,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -741,7 +741,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -832,7 +832,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1006,11 +1006,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -596,6 +596,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -684,6 +685,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -856,6 +860,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -596,7 +596,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -687,7 +687,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -861,9 +861,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -596,7 +596,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -685,9 +684,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -860,12 +856,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -596,7 +596,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -687,7 +687,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -861,11 +861,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -431,7 +431,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -522,7 +522,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -696,11 +696,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -431,7 +431,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -522,7 +522,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -696,9 +696,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -431,6 +431,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -519,6 +520,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -691,6 +695,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -431,7 +431,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -520,9 +519,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -695,12 +691,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -647,7 +647,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -736,9 +735,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -911,12 +907,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -647,6 +647,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -735,6 +736,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -907,6 +911,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -647,7 +647,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -738,7 +738,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -912,11 +912,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -647,7 +647,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -738,7 +738,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -912,9 +912,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -493,7 +493,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -584,7 +584,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -758,9 +758,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -493,6 +493,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -581,6 +582,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -753,6 +757,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -493,7 +493,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -584,7 +584,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -758,11 +758,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -493,7 +493,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -582,9 +581,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -757,12 +753,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -573,7 +573,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -662,9 +661,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -837,12 +833,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -573,7 +573,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -664,7 +664,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -838,11 +838,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -573,6 +573,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -661,6 +662,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -833,6 +837,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -573,7 +573,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -664,7 +664,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -838,9 +838,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/stateclone/stateclone.go
+++ b/test/stateclone/stateclone.go
@@ -659,6 +659,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -747,6 +748,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -919,6 +923,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/stateclone/stateclone.go
+++ b/test/stateclone/stateclone.go
@@ -659,7 +659,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -750,7 +750,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -924,9 +924,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/stateclone/stateclone.go
+++ b/test/stateclone/stateclone.go
@@ -659,7 +659,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -750,7 +750,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -924,11 +924,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/stateclone/stateclone.go
+++ b/test/stateclone/stateclone.go
@@ -659,7 +659,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -748,9 +747,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -923,12 +919,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/statereadonly/statereadonly.go
+++ b/test/statereadonly/statereadonly.go
@@ -640,6 +640,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -728,6 +729,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -900,6 +904,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/statereadonly/statereadonly.go
+++ b/test/statereadonly/statereadonly.go
@@ -640,7 +640,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -729,9 +728,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -904,12 +900,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/statereadonly/statereadonly.go
+++ b/test/statereadonly/statereadonly.go
@@ -640,7 +640,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -731,7 +731,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -905,9 +905,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/statereadonly/statereadonly.go
+++ b/test/statereadonly/statereadonly.go
@@ -640,7 +640,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -731,7 +731,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -905,11 +905,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -1526,7 +1526,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
+		emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1617,7 +1617,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
+	emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1791,11 +1791,12 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
+	if len(p.cur.state) == 0 {
+		if len(p.emptyState) > 0 {
+			p.emptyState = make(storeDict)
 		}
-	*/
+		return p.emptyState
+	}
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -1526,6 +1526,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1614,6 +1615,9 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
+
+	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1786,6 +1790,12 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
+
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -1526,7 +1526,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		emptyState: make(storeDict),
+		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1617,7 +1617,7 @@ type parser struct {
 	recoveryStack []map[string]interface{}
 
 	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	emptyState storeDict
+	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1791,9 +1791,11 @@ func (p *parser) cloneState() storeDict {
 		defer p.out(p.in("cloneState"))
 	}
 
-	if len(p.cur.state) == 0 {
-		return p.emptyState
-	}
+	/*
+		if len(p.cur.state) == 0 {
+			return p.emptyState
+		}
+	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -1526,7 +1526,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		Stats:           &stats,
 		// start rule is rule [0] unless an alternate entrypoint is specified
 		entrypoint: g.rules[0].name,
-		//emptyState: make(storeDict),
 	}
 	p.setOptions(opts)
 
@@ -1615,9 +1614,6 @@ type parser struct {
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
 	recoveryStack []map[string]interface{}
-
-	// emptyState contains an empty storeDict, which is used to optimize cloneState if global "state" store is not used.
-	//emptyState storeDict
 }
 
 // push a variable set on the vstack.
@@ -1790,12 +1786,6 @@ func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
-
-	/*
-		if len(p.cur.state) == 0 {
-			return p.emptyState
-		}
-	*/
 
 	state := make(storeDict, len(p.cur.state))
 	for k, v := range p.cur.state {


### PR DESCRIPTION
As discussed in #52 , the `emptyState` optimization (where a pre-allocated empty map is returned when cloning the backtrack-aware global state if it is empty) can cause issues if the state code blocks remove keys at some point. 

The sequence to reproduce the issue is detailed in #52, copied here for convenience and implemented in the `test/emptystate/emptystate.peg` test grammar:

* an expression causes the parser to clone with no state (p.cur.state is empty) so it returns emptyState, and then on restore it sets p.cur.state to the same as emptyState (an alias)
* state code block adds something (state["thing"] = 1), emptyState no longer empty (because p.cur.state is an alias)
* an expression causes the parser to clone state["thing"] == 1, then backtracks and restores the clone (p.cur.state is now not the same as emptyState - not an alias - but both contain state["thing" == 1)
* a subsequent state code block removes the thing (delete(state, "thing")), p.cur.state is now empty but not emptyState
* a subsequent expression causes the parser to clone the state, which is empty, so it returns emptyState, but emptyState is not empty, problems...
