### PR TITLE
Add -nolint flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,95 +68,98 @@ $(PIGEON_GRAMMAR):
 
 # surely there's a better way to define the examples and test targets
 $(EXAMPLES_DIR)/json/json.go: $(EXAMPLES_DIR)/json/json.peg $(EXAMPLES_DIR)/json/optimized/json.go $(EXAMPLES_DIR)/json/optimized-grammar/json.go $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(EXAMPLES_DIR)/json/optimized/json.go: $(EXAMPLES_DIR)/json/json.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon -optimize-parser -optimize-basic-latin $< > $@
+	$(BINDIR)/pigeon -nolint -optimize-parser -optimize-basic-latin $< > $@
 
 $(EXAMPLES_DIR)/json/optimized-grammar/json.go: $(EXAMPLES_DIR)/json/json.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon -optimize-grammar $< > $@
+	$(BINDIR)/pigeon -nolint -optimize-grammar $< > $@
 
 $(EXAMPLES_DIR)/calculator/calculator.go: $(EXAMPLES_DIR)/calculator/calculator.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(EXAMPLES_DIR)/indentation/indentation.go: $(EXAMPLES_DIR)/indentation/indentation.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/andnot/andnot.go: $(TEST_DIR)/andnot/andnot.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/predicates/predicates.go: $(TEST_DIR)/predicates/predicates.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/issue_1/issue_1.go: $(TEST_DIR)/issue_1/issue_1.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/linear/linear.go: $(TEST_DIR)/linear/linear.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/issue_18/issue_18.go: $(TEST_DIR)/issue_18/issue_18.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/runeerror/runeerror.go: $(TEST_DIR)/runeerror/runeerror.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/errorpos/errorpos.go: $(TEST_DIR)/errorpos/errorpos.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/global_store/global_store.go: $(TEST_DIR)/global_store/global_store.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/goto/goto.go: $(TEST_DIR)/goto/goto.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/goto_state/goto_state.go: $(TEST_DIR)/goto_state/goto_state.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/max_expr_cnt/maxexpr.go: $(TEST_DIR)/max_expr_cnt/maxexpr.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/labeled_failures/labeled_failures.go: $(TEST_DIR)/labeled_failures/labeled_failures.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/thrownrecover/thrownrecover.go: $(TEST_DIR)/thrownrecover/thrownrecover.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/alternate_entrypoint/altentry.go: $(TEST_DIR)/alternate_entrypoint/altentry.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon -optimize-grammar -alternate-entrypoints Entry2,Entry3,C $< > $@
+	$(BINDIR)/pigeon -nolint -optimize-grammar -alternate-entrypoints Entry2,Entry3,C $< > $@
 
 $(TEST_DIR)/state/state.go: $(TEST_DIR)/state/state.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon -optimize-grammar $< > $@
+	$(BINDIR)/pigeon -nolint -optimize-grammar $< > $@
 
 $(TEST_DIR)/stateclone/stateclone.go: $(TEST_DIR)/stateclone/stateclone.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/statereadonly/statereadonly.go: $(TEST_DIR)/statereadonly/statereadonly.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/staterestore/staterestore.go: $(TEST_DIR)/staterestore/staterestore.peg $(TEST_DIR)/staterestore/standard/staterestore.go $(TEST_DIR)/staterestore/optimized/staterestore.go $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/staterestore/standard/staterestore.go: $(TEST_DIR)/staterestore/staterestore.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/staterestore/optimized/staterestore.go: $(TEST_DIR)/staterestore/staterestore.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon -optimize-grammar -optimize-parser -alternate-entrypoints TestAnd,TestNot $< > $@
+	$(BINDIR)/pigeon -nolint -optimize-grammar -optimize-parser -alternate-entrypoints TestAnd,TestNot $< > $@
 
 $(TEST_DIR)/emptystate/emptystate.go: $(TEST_DIR)/emptystate/emptystate.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/issue_65/issue_65.go: $(TEST_DIR)/issue_65/issue_65.peg $(TEST_DIR)/issue_65/optimized/issue_65.go $(TEST_DIR)/issue_65/optimized-grammar/issue_65.go $(BINDIR)/pigeon
-	$(BINDIR)/pigeon $< > $@
+	$(BINDIR)/pigeon -nolint $< > $@
 
 $(TEST_DIR)/issue_65/optimized/issue_65.go: $(TEST_DIR)/issue_65/issue_65.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon -optimize-parser -optimize-basic-latin $< > $@
+	$(BINDIR)/pigeon -nolint -optimize-parser -optimize-basic-latin $< > $@
 
 $(TEST_DIR)/issue_65/optimized-grammar/issue_65.go: $(TEST_DIR)/issue_65/issue_65.peg $(BINDIR)/pigeon
-	$(BINDIR)/pigeon -optimize-grammar $< > $@
+	$(BINDIR)/pigeon -nolint -optimize-grammar $< > $@
 
 lint:
 	golint ./...
 	go vet ./...
+
+gometalinter:
+	gometalinter ./...
 
 cmp:
 	@boot=$$(mktemp) && $(BINDIR)/bootstrap-pigeon $(PIGEON_GRAMMAR) > $$boot && \
@@ -170,5 +173,5 @@ clean:
 	rm -f $(BOOTSTRAPPIGEON_DIR)/bootstrap_pigeon.go $(ROOT)/pigeon.go $(TEST_GENERATED_SRC) $(EXAMPLES_DIR)/json/optimized/json.go $(EXAMPLES_DIR)/json/optimized-grammar/json.go $(TEST_DIR)/staterestore/optimized/staterestore.go $(TEST_DIR)/staterestore/standard/staterestore.go $(TEST_DIR)/issue_65/optimized/issue_65.go $(TEST_DIR)/issue_65/optimized-grammar/issue_65.go
 	rm -rf $(BINDIR)
 
-.PHONY: all clean lint cmp
+.PHONY: all clean lint gometalinter cmp
 

--- a/bootstrap/cmd/bootstrap-pigeon/main.go
+++ b/bootstrap/cmd/bootstrap-pigeon/main.go
@@ -74,7 +74,8 @@ func main() {
 
 		outBuf := bytes.NewBuffer([]byte{})
 
-		if err := builder.BuildParser(outBuf, g.(*ast.Grammar)); err != nil {
+		nolintOpt := builder.Nolint(true)
+		if err := builder.BuildParser(outBuf, g.(*ast.Grammar), nolintOpt); err != nil {
 			fmt.Fprintln(os.Stderr, "build error: ", err)
 			os.Exit(5)
 		}

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -169,7 +169,7 @@ func InitState(key string, value interface{}) Option {
 // {{ end }} ==template==
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { //{{ if .Nolint }} nolint: deadcode {{else}} ==template== {{ end }}
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -184,7 +184,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { //{{ if .Nolint }} nolint: deadcode {{else}} ==template== {{ end }}
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -241,11 +241,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type rule struct {
 	pos         position
 	name        string
@@ -253,17 +255,20 @@ type rule struct {
 	expr        interface{}
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -271,33 +276,38 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
+type notExpr expr //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
+type zeroOrOneExpr expr //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
+type zeroOrMoreExpr expr //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
+type oneOrMoreExpr expr //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type ruleRefExpr struct {
 	pos  position
 	name string
@@ -305,6 +315,7 @@ type ruleRefExpr struct {
 
 // ==template== {{ if or .GlobalState (not .Optimize) }}
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
@@ -312,22 +323,26 @@ type stateCodeExpr struct {
 
 // {{ end }} ==template==
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -339,7 +354,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -444,12 +459,15 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+
+//{{ if .Nolint }} nolint: structcheck,deadcode {{else}} ==template== {{ end }}
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+//{{ if .Nolint }} nolint: varcheck {{else}} ==template== {{ end }}
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -474,6 +492,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+//{{ if .Nolint }} nolint: structcheck,maligned {{else}} ==template== {{ end }}
 type parser struct {
 	filename string
 	pt       savepoint
@@ -772,6 +791,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+//{{ if .Nolint }} nolint: gocyclo {{else}} ==template== {{ end }}
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -884,6 +904,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+//{{ if .Nolint }} nolint: gocyclo {{else}} ==template== {{ end }}
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	// ==template== {{ if not .Optimize }}
 	var pt savepoint
@@ -1051,6 +1072,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+//{{ if .Nolint }} nolint: gocyclo {{else}} ==template== {{ end }}
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	// ==template== {{ if not .Optimize }}
 	if p.debug {

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -185,7 +185,7 @@ func InitState(key string, value interface{}) Option {
 // {{ end }} ==template==
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { //{{ if .Nolint }} nolint: deadcode {{else}} ==template== {{ end }}
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -200,7 +200,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { //{{ if .Nolint }} nolint: deadcode {{else}} ==template== {{ end }}
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -257,11 +257,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type rule struct {
 	pos         position
 	name        string
@@ -269,17 +271,20 @@ type rule struct {
 	expr        interface{}
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -287,33 +292,38 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
+type notExpr expr //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
+type zeroOrOneExpr expr //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
+type zeroOrMoreExpr expr //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
+type oneOrMoreExpr expr //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type ruleRefExpr struct {
 	pos  position
 	name string
@@ -321,6 +331,7 @@ type ruleRefExpr struct {
 
 // ==template== {{ if or .GlobalState (not .Optimize) }}
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
@@ -328,22 +339,26 @@ type stateCodeExpr struct {
 
 // {{ end }} ==template==
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+//{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -355,7 +370,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -460,12 +475,15 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+
+//{{ if .Nolint }} nolint: structcheck,deadcode {{else}} ==template== {{ end }}
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+//{{ if .Nolint }} nolint: varcheck {{else}} ==template== {{ end }}
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -490,6 +508,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+//{{ if .Nolint }} nolint: structcheck,maligned {{else}} ==template== {{ end }}
 type parser struct {
 	filename string
 	pt       savepoint
@@ -788,6 +807,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+//{{ if .Nolint }} nolint: gocyclo {{else}} ==template== {{ end }}
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -900,6 +920,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+//{{ if .Nolint }} nolint: gocyclo {{else}} ==template== {{ end }}
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	// ==template== {{ if not .Optimize }}
 	var pt savepoint
@@ -1067,6 +1088,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+//{{ if .Nolint }} nolint: gocyclo {{else}} ==template== {{ end }}
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	// ==template== {{ if not .Optimize }}
 	if p.debug {

--- a/doc.go
+++ b/doc.go
@@ -35,6 +35,9 @@ The following options can be specified:
 
 	-debug : boolean, print debugging info to stdout (default: false).
 
+	-nolint: add '// nolint: ...' comments for generated parser to suppress
+	warnings by gometalinter (https://github.com/alecthomas/gometalinter).
+
 	-no-recover : boolean, if set, do not recover from a panic. Useful
 	to access the panic stack when debugging, otherwise the panic
 	is converted to an error (default: false).

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -606,7 +606,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -621,7 +621,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -674,11 +674,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -686,17 +688,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -704,59 +709,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -768,7 +783,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -869,12 +884,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -899,6 +916,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1179,6 +1197,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1285,6 +1304,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1423,6 +1443,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/examples/indentation/indentation.go
+++ b/examples/indentation/indentation.go
@@ -913,7 +913,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -928,7 +928,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -981,11 +981,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -993,17 +995,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -1011,59 +1016,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -1075,7 +1090,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -1176,12 +1191,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -1206,6 +1223,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1486,6 +1504,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1592,6 +1611,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1730,6 +1750,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -900,7 +900,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -915,7 +915,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -968,11 +968,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -980,17 +982,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -998,59 +1003,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -1062,7 +1077,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -1163,12 +1178,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -1193,6 +1210,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1473,6 +1491,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1579,6 +1598,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1717,6 +1737,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -1071,7 +1071,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -1086,7 +1086,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -1139,11 +1139,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -1151,17 +1153,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -1169,59 +1174,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -1233,7 +1248,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -1334,12 +1349,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -1364,6 +1381,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1644,6 +1662,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1750,6 +1769,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1888,6 +1908,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -840,7 +840,7 @@ func GlobalStore(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -855,7 +855,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -903,11 +903,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -915,17 +917,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -933,54 +938,63 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -992,7 +1006,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -1091,12 +1105,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -1121,6 +1137,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1304,6 +1321,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1387,6 +1405,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 
 	p.ExprCnt++
@@ -1485,6 +1504,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	cur := p.pt.rn
 	start := p.pt

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func main() {
 		dbgFlag                = fs.Bool("debug", false, "set debug mode")
 		shortHelpFlag          = fs.Bool("h", false, "show help page")
 		longHelpFlag           = fs.Bool("help", false, "show help page")
+		nolint                 = fs.Bool("nolint", false, "add '// nolint: ...' comments to suppress warnings by gometalinter")
 		noRecoverFlag          = fs.Bool("no-recover", false, "do not recover from panic")
 		outputFlag             = fs.String("o", "", "output file, defaults to stdout")
 		optimizeBasicLatinFlag = fs.Bool("optimize-basic-latin", false, "generate optimized parser for Unicode Basic Latin character sets")
@@ -134,7 +135,8 @@ func main() {
 		curNmOpt := builder.ReceiverName(*recvrNmFlag)
 		optimizeParser := builder.Optimize(*optimizeParserFlag)
 		basicLatinOptimize := builder.BasicLatinLookupTable(*optimizeBasicLatinFlag)
-		if err := builder.BuildParser(outBuf, grammar, curNmOpt, optimizeParser, basicLatinOptimize); err != nil {
+		nolintOpt := builder.Nolint(*nolint)
+		if err := builder.BuildParser(outBuf, grammar, curNmOpt, optimizeParser, basicLatinOptimize, nolintOpt); err != nil {
 			fmt.Fprintln(os.Stderr, "build error: ", err)
 			exit(5)
 		}
@@ -181,6 +183,9 @@ the generated code is written to this file instead.
 		output debugging information while parsing the grammar.
 	-h -help
 		display this help message.
+	-nolint
+		add '// nolint: ...' comments for generated parser to suppress
+		warnings by gometalinter (https://github.com/alecthomas/gometalinter).
 	-no-recover
 		do not recover from a panic. Useful to access the panic stack
 		when debugging, otherwise the panic is converted to an error.

--- a/pigeon.go
+++ b/pigeon.go
@@ -3264,7 +3264,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -3279,7 +3279,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -3332,11 +3332,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -3344,17 +3346,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -3362,59 +3367,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -3426,7 +3441,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -3527,12 +3542,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -3557,6 +3574,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -3837,6 +3855,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -3943,6 +3962,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -4081,6 +4101,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -375,7 +375,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -390,7 +390,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -443,11 +443,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -455,17 +457,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -473,59 +478,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -537,7 +552,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -638,12 +653,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -668,6 +685,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -948,6 +966,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1054,6 +1073,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1192,6 +1212,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -321,7 +321,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -336,7 +336,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -389,11 +389,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -401,17 +403,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -419,59 +424,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -483,7 +498,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -584,12 +599,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -614,6 +631,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -894,6 +912,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1000,6 +1019,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1138,6 +1158,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/emptystate/emptystate.go
+++ b/test/emptystate/emptystate.go
@@ -376,7 +376,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -391,7 +391,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -444,11 +444,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -456,17 +458,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -474,59 +479,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -538,7 +553,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -639,12 +654,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -669,6 +686,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -949,6 +967,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1055,6 +1074,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1193,6 +1213,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -736,7 +736,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -751,7 +751,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -804,11 +804,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -816,17 +818,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -834,59 +839,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -898,7 +913,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -999,12 +1014,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -1029,6 +1046,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1309,6 +1327,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1415,6 +1434,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1553,6 +1573,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -339,7 +339,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -354,7 +354,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -407,11 +407,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -419,17 +421,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -437,59 +442,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -501,7 +516,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -602,12 +617,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -632,6 +649,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -912,6 +930,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1018,6 +1037,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1156,6 +1176,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -556,7 +556,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -571,7 +571,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -624,11 +624,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -636,17 +638,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -654,59 +659,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -718,7 +733,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -819,12 +834,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -849,6 +866,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1129,6 +1147,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1235,6 +1254,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1373,6 +1393,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/goto_state/goto_state.go
+++ b/test/goto_state/goto_state.go
@@ -584,7 +584,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -599,7 +599,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -652,11 +652,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -664,17 +666,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -682,59 +687,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -746,7 +761,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -847,12 +862,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -877,6 +894,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1157,6 +1175,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1263,6 +1282,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1401,6 +1421,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -260,7 +260,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -275,7 +275,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -328,11 +328,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -340,17 +342,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -358,59 +363,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -422,7 +437,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -523,12 +538,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -553,6 +570,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -833,6 +851,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -939,6 +958,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1077,6 +1097,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -278,7 +278,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -293,7 +293,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -346,11 +346,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -358,17 +360,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -376,59 +381,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -440,7 +455,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -541,12 +556,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -571,6 +588,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -851,6 +869,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -957,6 +976,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1095,6 +1115,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/issue_65/issue_65.go
+++ b/test/issue_65/issue_65.go
@@ -274,7 +274,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -289,7 +289,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -342,11 +342,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -354,17 +356,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -372,59 +377,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -436,7 +451,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -537,12 +552,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -567,6 +584,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -847,6 +865,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -953,6 +972,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1091,6 +1111,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/issue_65/optimized-grammar/issue_65.go
+++ b/test/issue_65/optimized-grammar/issue_65.go
@@ -248,7 +248,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -263,7 +263,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -316,11 +316,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -328,17 +330,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -346,59 +351,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -410,7 +425,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -511,12 +526,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -541,6 +558,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -821,6 +839,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -927,6 +946,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1065,6 +1085,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/issue_65/optimized/issue_65.go
+++ b/test/issue_65/optimized/issue_65.go
@@ -206,7 +206,7 @@ func GlobalStore(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -221,7 +221,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -269,11 +269,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -281,17 +283,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -299,54 +304,63 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -358,7 +372,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -457,12 +471,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -487,6 +503,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -670,6 +687,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -753,6 +771,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 
 	p.ExprCnt++
@@ -851,6 +870,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	cur := p.pt.rn
 	start := p.pt

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -498,7 +498,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -513,7 +513,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -566,11 +566,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -578,17 +580,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -596,59 +601,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -660,7 +675,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -761,12 +776,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -791,6 +808,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1071,6 +1089,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1177,6 +1196,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1315,6 +1335,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -353,7 +353,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -368,7 +368,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -421,11 +421,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -433,17 +435,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -451,59 +456,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -515,7 +530,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -616,12 +631,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -646,6 +663,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -926,6 +944,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1032,6 +1051,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1170,6 +1190,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -188,7 +188,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -203,7 +203,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -256,11 +256,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -268,17 +270,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -286,59 +291,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -350,7 +365,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -451,12 +466,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -481,6 +498,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -761,6 +779,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -867,6 +886,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1005,6 +1025,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -404,7 +404,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -419,7 +419,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -472,11 +472,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -484,17 +486,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -502,59 +507,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -566,7 +581,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -667,12 +682,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -697,6 +714,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -977,6 +995,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1083,6 +1102,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1221,6 +1241,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -250,7 +250,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -265,7 +265,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -318,11 +318,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -330,17 +332,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -348,59 +353,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -412,7 +427,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -513,12 +528,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -543,6 +560,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -823,6 +841,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -929,6 +948,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1067,6 +1087,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -330,7 +330,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -345,7 +345,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -398,11 +398,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -410,17 +412,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -428,59 +433,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -492,7 +507,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -593,12 +608,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -623,6 +640,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -903,6 +921,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1009,6 +1028,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1147,6 +1167,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/stateclone/stateclone.go
+++ b/test/stateclone/stateclone.go
@@ -416,7 +416,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -431,7 +431,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -484,11 +484,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -496,17 +498,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -514,59 +519,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -578,7 +593,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -679,12 +694,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -709,6 +726,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -989,6 +1007,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1095,6 +1114,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1233,6 +1253,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/statereadonly/statereadonly.go
+++ b/test/statereadonly/statereadonly.go
@@ -397,7 +397,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -412,7 +412,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -465,11 +465,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -477,17 +479,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -495,59 +500,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -559,7 +574,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -660,12 +675,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -690,6 +707,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -970,6 +988,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1076,6 +1095,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1214,6 +1234,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/staterestore/optimized/staterestore.go
+++ b/test/staterestore/optimized/staterestore.go
@@ -760,7 +760,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -775,7 +775,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -828,11 +828,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -840,17 +842,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -858,59 +863,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -922,7 +937,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -1023,12 +1038,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -1053,6 +1070,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1274,6 +1292,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1357,6 +1376,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 
 	p.ExprCnt++
@@ -1463,6 +1483,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	cur := p.pt.rn
 	start := p.pt

--- a/test/staterestore/standard/staterestore.go
+++ b/test/staterestore/standard/staterestore.go
@@ -501,7 +501,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -516,7 +516,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -569,11 +569,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -581,17 +583,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -599,59 +604,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -663,7 +678,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -764,12 +779,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -794,6 +811,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1074,6 +1092,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1180,6 +1199,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1318,6 +1338,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/staterestore/staterestore.go
+++ b/test/staterestore/staterestore.go
@@ -501,7 +501,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -516,7 +516,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -569,11 +569,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -581,17 +583,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -599,59 +604,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -663,7 +678,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -764,12 +779,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -794,6 +811,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1074,6 +1092,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1180,6 +1199,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -1318,6 +1338,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -1283,7 +1283,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) { // nolint: deadcode
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -1298,7 +1298,7 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) { // nolint: deadcode
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -1351,11 +1351,13 @@ type storeDict map[string]interface{}
 
 // the AST types...
 
+// nolint: structcheck
 type grammar struct {
 	pos   position
 	rules []*rule
 }
 
+// nolint: structcheck
 type rule struct {
 	pos         position
 	name        string
@@ -1363,17 +1365,20 @@ type rule struct {
 	expr        interface{}
 }
 
+// nolint: structcheck
 type choiceExpr struct {
 	pos          position
 	alternatives []interface{}
 }
 
+// nolint: structcheck
 type actionExpr struct {
 	pos  position
 	expr interface{}
 	run  func(*parser) (interface{}, error)
 }
 
+// nolint: structcheck
 type recoveryExpr struct {
 	pos          position
 	expr         interface{}
@@ -1381,59 +1386,69 @@ type recoveryExpr struct {
 	failureLabel []string
 }
 
+// nolint: structcheck
 type seqExpr struct {
 	pos   position
 	exprs []interface{}
 }
 
+// nolint: structcheck
 type throwExpr struct {
 	pos   position
 	label string
 }
 
+// nolint: structcheck
 type labeledExpr struct {
 	pos   position
 	label string
 	expr  interface{}
 }
 
+// nolint: structcheck
 type expr struct {
 	pos  position
 	expr interface{}
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type andExpr expr        // nolint: structcheck
+type notExpr expr        // nolint: structcheck
+type zeroOrOneExpr expr  // nolint: structcheck
+type zeroOrMoreExpr expr // nolint: structcheck
+type oneOrMoreExpr expr  // nolint: structcheck
 
+// nolint: structcheck
 type ruleRefExpr struct {
 	pos  position
 	name string
 }
 
+// nolint: structcheck
 type stateCodeExpr struct {
 	pos position
 	run func(*parser) error
 }
 
+// nolint: structcheck
 type andCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type notCodeExpr struct {
 	pos position
 	run func(*parser) (bool, error)
 }
 
+// nolint: structcheck
 type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
 }
 
+// nolint: structcheck
 type charClassMatcher struct {
 	pos             position
 	val             string
@@ -1445,7 +1460,7 @@ type charClassMatcher struct {
 	inverted        bool
 }
 
-type anyMatcher position
+type anyMatcher position // nolint: structcheck
 
 // errList cumulates the errors found by the parser.
 type errList []error
@@ -1546,12 +1561,14 @@ func (p *parser) setOptions(opts []Option) {
 	}
 }
 
+// nolint: structcheck,deadcode
 type resultTuple struct {
 	v   interface{}
 	b   bool
 	end savepoint
 }
 
+// nolint: varcheck
 const choiceNoMatch = -1
 
 // Stats stores some statistics, gathered during parsing
@@ -1576,6 +1593,7 @@ type Stats struct {
 	ChoiceAltCnt map[string]map[string]int
 }
 
+// nolint: structcheck,maligned
 type parser struct {
 	filename string
 	pt       savepoint
@@ -1856,6 +1874,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
+// nolint: gocyclo
 func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
@@ -1962,6 +1981,7 @@ func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	return val, ok
 }
 
+// nolint: gocyclo
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
@@ -2100,6 +2120,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
+// nolint: gocyclo
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))


### PR DESCRIPTION
If the -nolint flag is provided to pigeon, special comments in
the format '// nolint: ...' are added to the source code of the
generated parser. Those comments are understood by [gometalinter].
The respective linter warnings are then ignored.

[gometalinter]: https://github.com/alecthomas/gometalinter