### PR TITLE
use memory pool for storeDicts

### DIFF
--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 
@@ -2828,13 +2829,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -2851,6 +2863,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -706,7 +706,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -705,6 +705,17 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	// ==template== {{ if not .Optimize }}
@@ -713,7 +724,7 @@ func (p *parser) cloneState() storeDict {
 	}
 	// {{ end }} ==template==
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -732,6 +743,7 @@ func (p *parser) restoreState(state storeDict) {
 		defer p.out(p.in("restoreState"))
 	}
 	// {{ end }} ==template==
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -724,7 +724,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -722,6 +723,17 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	// ==template== {{ if not .Optimize }}
@@ -730,7 +742,7 @@ func (p *parser) cloneState() storeDict {
 	}
 	// {{ end }} ==template==
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -749,6 +761,7 @@ func (p *parser) restoreState(state storeDict) {
 		defer p.out(p.in("restoreState"))
 	}
 	// {{ end }} ==template==
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -1124,13 +1125,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -1147,6 +1159,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -1126,7 +1126,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/examples/indentation/indentation.go
+++ b/examples/indentation/indentation.go
@@ -1433,7 +1433,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/examples/indentation/indentation.go
+++ b/examples/indentation/indentation.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -1431,13 +1432,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -1454,6 +1466,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -1418,13 +1419,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -1441,6 +1453,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -1420,7 +1420,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -1591,7 +1591,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -1589,13 +1590,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -1612,6 +1624,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/pigeon.go
+++ b/pigeon.go
@@ -3793,7 +3793,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/pigeon.go
+++ b/pigeon.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 
@@ -3791,13 +3792,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -3814,6 +3826,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -895,7 +895,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -893,13 +894,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -916,6 +928,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -841,7 +841,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -839,13 +840,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -862,6 +874,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/emptystate/emptystate.go
+++ b/test/emptystate/emptystate.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -894,13 +895,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -917,6 +929,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/emptystate/emptystate.go
+++ b/test/emptystate/emptystate.go
@@ -896,7 +896,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -1256,7 +1256,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -1254,13 +1255,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -1277,6 +1289,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -857,13 +858,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -880,6 +892,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -859,7 +859,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -1074,13 +1075,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -1097,6 +1109,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -1076,7 +1076,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/goto_state/goto_state.go
+++ b/test/goto_state/goto_state.go
@@ -1104,7 +1104,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/goto_state/goto_state.go
+++ b/test/goto_state/goto_state.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -1102,13 +1103,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -1125,6 +1137,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -778,13 +779,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -801,6 +813,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -780,7 +780,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -798,7 +798,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -796,13 +797,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -819,6 +831,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/issue_65/issue_65.go
+++ b/test/issue_65/issue_65.go
@@ -794,7 +794,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/issue_65/issue_65.go
+++ b/test/issue_65/issue_65.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -792,13 +793,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -815,6 +827,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/issue_65/optimized-grammar/issue_65.go
+++ b/test/issue_65/optimized-grammar/issue_65.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -777,13 +778,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -800,6 +812,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/issue_65/optimized-grammar/issue_65.go
+++ b/test/issue_65/optimized-grammar/issue_65.go
@@ -779,7 +779,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/issue_70/issue_70.go
+++ b/test/issue_70/issue_70.go
@@ -771,7 +771,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/issue_70/issue_70.go
+++ b/test/issue_70/issue_70.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -769,13 +770,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -792,6 +804,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/issue_70/optimized-grammar/issue_70.go
+++ b/test/issue_70/optimized-grammar/issue_70.go
@@ -755,7 +755,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/issue_70/optimized-grammar/issue_70.go
+++ b/test/issue_70/optimized-grammar/issue_70.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -753,13 +754,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -776,6 +788,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/issue_70b/issue_70b.go
+++ b/test/issue_70b/issue_70b.go
@@ -757,7 +757,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/issue_80/issue_80.go
+++ b/test/issue_80/issue_80.go
@@ -791,7 +791,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/issue_80/issue_80.go
+++ b/test/issue_80/issue_80.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -789,13 +790,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -812,6 +824,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -1018,7 +1018,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -1016,13 +1017,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -1039,6 +1051,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -871,13 +872,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -894,6 +906,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -873,7 +873,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -708,7 +708,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -706,13 +707,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -729,6 +741,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -924,7 +924,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -922,13 +923,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -945,6 +957,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -770,7 +770,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -768,13 +769,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -791,6 +803,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -850,7 +850,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -848,13 +849,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -871,6 +883,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/stateclone/stateclone.go
+++ b/test/stateclone/stateclone.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -934,13 +935,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -957,6 +969,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/stateclone/stateclone.go
+++ b/test/stateclone/stateclone.go
@@ -936,7 +936,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/statereadonly/statereadonly.go
+++ b/test/statereadonly/statereadonly.go
@@ -917,7 +917,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/statereadonly/statereadonly.go
+++ b/test/statereadonly/statereadonly.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -915,13 +916,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -938,6 +950,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/staterestore/optimized/staterestore.go
+++ b/test/staterestore/optimized/staterestore.go
@@ -1251,7 +1251,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/staterestore/optimized/staterestore.go
+++ b/test/staterestore/optimized/staterestore.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -1249,10 +1250,21 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -1266,6 +1278,7 @@ func (p *parser) cloneState() storeDict {
 // restore parser current state to the state storeDict.
 // every restoreState should applied only one time for every cloned state
 func (p *parser) restoreState(state storeDict) {
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/staterestore/standard/staterestore.go
+++ b/test/staterestore/standard/staterestore.go
@@ -1021,7 +1021,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/staterestore/standard/staterestore.go
+++ b/test/staterestore/standard/staterestore.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -1019,13 +1020,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -1042,6 +1054,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/staterestore/staterestore.go
+++ b/test/staterestore/staterestore.go
@@ -1021,7 +1021,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {

--- a/test/staterestore/staterestore.go
+++ b/test/staterestore/staterestore.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -1019,13 +1020,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -1042,6 +1054,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -1801,13 +1802,24 @@ type Cloner interface {
 	Clone() interface{}
 }
 
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict, 2) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
 // clone and return parser current state.
 func (p *parser) cloneState() storeDict {
 	if p.debug {
 		defer p.out(p.in("cloneState"))
 	}
 
-	state := make(storeDict, len(p.cur.state))
+	state := statePool.Get().(storeDict)
 	for k, v := range p.cur.state {
 		if c, ok := v.(Cloner); ok {
 			state[k] = c.Clone()
@@ -1824,6 +1836,7 @@ func (p *parser) restoreState(state storeDict) {
 	if p.debug {
 		defer p.out(p.in("restoreState"))
 	}
+	p.cur.state.Discard()
 	p.cur.state = state
 }
 

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -1803,7 +1803,7 @@ type Cloner interface {
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict, 2) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {


### PR DESCRIPTION
This is important to reduce GC pressure in applications that spend a lot of time parsing. Let me know if you want more details on this, but we're already using this on our end, so would be great if we can merge it upstream.

@mna @breml 

EDIT: also let me know if you think we should write benchmarks to verify this