### PR TITLE
use go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: go
 
-install: go get golang.org/x/tools/imports/...
-
-script: go test -v ./...
+script: make test
 
 go:
-    - 1.9.x
-    - 1.10.x
     - 1.11.x
     - 1.12.x
     - tip

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 SHELL = /bin/bash
 
+# force the use of go modules
+export GO111MODULE = on
+
 # directories and source code lists
 ROOT = .
 ROOT_SRC = $(ROOT)/*.go
@@ -183,10 +186,13 @@ cmp:
 	unlink $$boot && \
 	unlink $$official
 
+test:
+	go test -v ./...
+
 clean:
 	rm -f $(BUILDER_DIR)/generated_static_code.go $(BUILDER_DIR)/generated_static_code_range_table.go
 	rm -f $(BOOTSTRAPPIGEON_DIR)/bootstrap_pigeon.go $(ROOT)/pigeon.go $(TEST_GENERATED_SRC) $(EXAMPLES_DIR)/json/optimized/json.go $(EXAMPLES_DIR)/json/optimized-grammar/json.go $(TEST_DIR)/staterestore/optimized/staterestore.go $(TEST_DIR)/staterestore/standard/staterestore.go $(TEST_DIR)/issue_65/optimized/issue_65.go $(TEST_DIR)/issue_65/optimized-grammar/issue_65.go
 	rm -rf $(BINDIR)
 
-.PHONY: all clean lint gometalinter cmp
+.PHONY: all clean lint gometalinter cmp test
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Github user [@mna][6] created the package in April 2015, and [@breml][5] is the 
 
 ### Breaking Changes since v1.0.0
 
+* Removed support for Go < v1.11 to support go modules for dependency tracking.
+
 * Removed support for Go < v1.9 due to the requirement [golang.org/x/tools/imports](https://godoc.org/golang.org/x/tools/imports), which was updated to reflect changes in recent versions of Go. This is in compliance with the [Go Release Policy](https://golang.org/doc/devel/release.html#policy) respectively the [Go Release Maintenance](https://github.com/golang/go/wiki/Go-Release-Cycle#release-maintenance), which states support for each major release until there are two newer major releases.
 
 ## Installation

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mna/pigeon
+
+require golang.org/x/tools v0.0.0-20190830223141-573d9926052a

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190830223141-573d9926052a h1:XAHT1kdPpnU8Hk+FPi42KZFhtNFEk4vBg1U4OmIeHTU=
+golang.org/x/tools v0.0.0-20190830223141-573d9926052a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Hi, I am packaging pigeon for [nixpkgs](https://github.com/NixOS/nixpkgs).

This makes the builds more reproducible by pinning the dependencies with go
modules. And also helps me to package future releases quicker.

This requires a version of Go 1.11 or higher to work properly.