### PR TITLE
Cache `want` in litMatcher

### DIFF
--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -210,6 +210,7 @@ var g = &grammar{
 											pos:        position{line: 43, col: 41, offset: 1026},
 											val:        "/",
 											ignoreCase: false,
+											want:       "\"/\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 43, col: 45, offset: 1030},
@@ -337,6 +338,7 @@ var g = &grammar{
 									pos:        position{line: 85, col: 35, offset: 2169},
 									val:        ":",
 									ignoreCase: false,
+									want:       "\":\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 85, col: 39, offset: 2173},
@@ -415,11 +417,13 @@ var g = &grammar{
 							pos:        position{line: 106, col: 16, offset: 2720},
 							val:        "&",
 							ignoreCase: false,
+							want:       "\"&\"",
 						},
 						&litMatcher{
 							pos:        position{line: 106, col: 22, offset: 2726},
 							val:        "!",
 							ignoreCase: false,
+							want:       "\"!\"",
 						},
 					},
 				},
@@ -480,16 +484,19 @@ var g = &grammar{
 							pos:        position{line: 131, col: 16, offset: 3369},
 							val:        "?",
 							ignoreCase: false,
+							want:       "\"?\"",
 						},
 						&litMatcher{
 							pos:        position{line: 131, col: 22, offset: 3375},
 							val:        "*",
 							ignoreCase: false,
+							want:       "\"*\"",
 						},
 						&litMatcher{
 							pos:        position{line: 131, col: 28, offset: 3381},
 							val:        "+",
 							ignoreCase: false,
+							want:       "\"+\"",
 						},
 					},
 				},
@@ -531,6 +538,7 @@ var g = &grammar{
 									pos:        position{line: 135, col: 93, offset: 3517},
 									val:        "(",
 									ignoreCase: false,
+									want:       "\"(\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 135, col: 97, offset: 3521},
@@ -552,6 +560,7 @@ var g = &grammar{
 									pos:        position{line: 135, col: 119, offset: 3543},
 									val:        ")",
 									ignoreCase: false,
+									want:       "\")\"",
 								},
 							},
 						},
@@ -658,11 +667,13 @@ var g = &grammar{
 							pos:        position{line: 154, col: 20, offset: 4097},
 							val:        "&",
 							ignoreCase: false,
+							want:       "\"&\"",
 						},
 						&litMatcher{
 							pos:        position{line: 154, col: 26, offset: 4103},
 							val:        "!",
 							ignoreCase: false,
+							want:       "\"!\"",
 						},
 					},
 				},
@@ -678,21 +689,25 @@ var g = &grammar{
 						pos:        position{line: 158, col: 13, offset: 4159},
 						val:        "=",
 						ignoreCase: false,
+						want:       "\"=\"",
 					},
 					&litMatcher{
 						pos:        position{line: 158, col: 19, offset: 4165},
 						val:        "<-",
 						ignoreCase: false,
+						want:       "\"<-\"",
 					},
 					&litMatcher{
 						pos:        position{line: 158, col: 26, offset: 4172},
 						val:        "←",
 						ignoreCase: false,
+						want:       "\"←\"",
 					},
 					&litMatcher{
 						pos:        position{line: 158, col: 37, offset: 4183},
 						val:        "⟵",
 						ignoreCase: false,
+						want:       "\"⟵\"",
 					},
 				},
 			},
@@ -731,6 +746,7 @@ var g = &grammar{
 						pos:        position{line: 162, col: 20, offset: 4280},
 						val:        "/*",
 						ignoreCase: false,
+						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
 						pos: position{line: 162, col: 27, offset: 4287},
@@ -743,6 +759,7 @@ var g = &grammar{
 										pos:        position{line: 162, col: 28, offset: 4288},
 										val:        "*/",
 										ignoreCase: false,
+										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
@@ -756,6 +773,7 @@ var g = &grammar{
 						pos:        position{line: 162, col: 47, offset: 4307},
 						val:        "*/",
 						ignoreCase: false,
+						want:       "\"*/\"",
 					},
 				},
 			},
@@ -770,6 +788,7 @@ var g = &grammar{
 						pos:        position{line: 163, col: 36, offset: 4349},
 						val:        "/*",
 						ignoreCase: false,
+						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
 						pos: position{line: 163, col: 43, offset: 4356},
@@ -785,6 +804,7 @@ var g = &grammar{
 												pos:        position{line: 163, col: 46, offset: 4359},
 												val:        "*/",
 												ignoreCase: false,
+												want:       "\"*/\"",
 											},
 											&ruleRefExpr{
 												pos:  position{line: 163, col: 53, offset: 4366},
@@ -804,6 +824,7 @@ var g = &grammar{
 						pos:        position{line: 163, col: 73, offset: 4386},
 						val:        "*/",
 						ignoreCase: false,
+						want:       "\"*/\"",
 					},
 				},
 			},
@@ -818,6 +839,7 @@ var g = &grammar{
 						pos:        position{line: 164, col: 21, offset: 4413},
 						val:        "//",
 						ignoreCase: false,
+						want:       "\"//\"",
 					},
 					&zeroOrMoreExpr{
 						pos: position{line: 164, col: 28, offset: 4420},
@@ -931,6 +953,7 @@ var g = &grammar{
 									pos:        position{line: 173, col: 39, offset: 4699},
 									val:        "i",
 									ignoreCase: false,
+									want:       "\"i\"",
 								},
 							},
 						},
@@ -954,6 +977,7 @@ var g = &grammar{
 									pos:        position{line: 183, col: 19, offset: 4945},
 									val:        "\"",
 									ignoreCase: false,
+									want:       "\"\\\"\"",
 								},
 								&zeroOrMoreExpr{
 									pos: position{line: 183, col: 23, offset: 4949},
@@ -966,6 +990,7 @@ var g = &grammar{
 									pos:        position{line: 183, col: 41, offset: 4967},
 									val:        "\"",
 									ignoreCase: false,
+									want:       "\"\\\"\"",
 								},
 							},
 						},
@@ -976,6 +1001,7 @@ var g = &grammar{
 									pos:        position{line: 183, col: 47, offset: 4973},
 									val:        "'",
 									ignoreCase: false,
+									want:       "\"'\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 183, col: 51, offset: 4977},
@@ -985,6 +1011,7 @@ var g = &grammar{
 									pos:        position{line: 183, col: 68, offset: 4994},
 									val:        "'",
 									ignoreCase: false,
+									want:       "\"'\"",
 								},
 							},
 						},
@@ -995,6 +1022,7 @@ var g = &grammar{
 									pos:        position{line: 183, col: 74, offset: 5000},
 									val:        "`",
 									ignoreCase: false,
+									want:       "\"`\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 183, col: 78, offset: 5004},
@@ -1004,6 +1032,7 @@ var g = &grammar{
 									pos:        position{line: 183, col: 92, offset: 5018},
 									val:        "`",
 									ignoreCase: false,
+									want:       "\"`\"",
 								},
 							},
 						},
@@ -1029,11 +1058,13 @@ var g = &grammar{
 											pos:        position{line: 186, col: 23, offset: 5113},
 											val:        "\"",
 											ignoreCase: false,
+											want:       "\"\\\"\"",
 										},
 										&litMatcher{
 											pos:        position{line: 186, col: 29, offset: 5119},
 											val:        "\\",
 											ignoreCase: false,
+											want:       "\"\\\\\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 186, col: 36, offset: 5126},
@@ -1055,6 +1086,7 @@ var g = &grammar{
 								pos:        position{line: 186, col: 55, offset: 5145},
 								val:        "\\",
 								ignoreCase: false,
+								want:       "\"\\\\\"",
 							},
 							&ruleRefExpr{
 								pos:  position{line: 186, col: 60, offset: 5150},
@@ -1083,11 +1115,13 @@ var g = &grammar{
 											pos:        position{line: 187, col: 23, offset: 5193},
 											val:        "'",
 											ignoreCase: false,
+											want:       "\"'\"",
 										},
 										&litMatcher{
 											pos:        position{line: 187, col: 29, offset: 5199},
 											val:        "\\",
 											ignoreCase: false,
+											want:       "\"\\\\\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 187, col: 36, offset: 5206},
@@ -1109,6 +1143,7 @@ var g = &grammar{
 								pos:        position{line: 187, col: 55, offset: 5225},
 								val:        "\\",
 								ignoreCase: false,
+								want:       "\"\\\\\"",
 							},
 							&ruleRefExpr{
 								pos:  position{line: 187, col: 60, offset: 5230},
@@ -1131,6 +1166,7 @@ var g = &grammar{
 							pos:        position{line: 188, col: 18, offset: 5268},
 							val:        "`",
 							ignoreCase: false,
+							want:       "\"`\"",
 						},
 					},
 					&ruleRefExpr{
@@ -1150,6 +1186,7 @@ var g = &grammar{
 						pos:        position{line: 190, col: 22, offset: 5307},
 						val:        "'",
 						ignoreCase: false,
+						want:       "\"'\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 190, col: 28, offset: 5313},
@@ -1168,6 +1205,7 @@ var g = &grammar{
 						pos:        position{line: 191, col: 22, offset: 5357},
 						val:        "\"",
 						ignoreCase: false,
+						want:       "\"\\\"\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 191, col: 28, offset: 5363},
@@ -1215,41 +1253,49 @@ var g = &grammar{
 						pos:        position{line: 194, col: 20, offset: 5515},
 						val:        "a",
 						ignoreCase: false,
+						want:       "\"a\"",
 					},
 					&litMatcher{
 						pos:        position{line: 194, col: 26, offset: 5521},
 						val:        "b",
 						ignoreCase: false,
+						want:       "\"b\"",
 					},
 					&litMatcher{
 						pos:        position{line: 194, col: 32, offset: 5527},
 						val:        "n",
 						ignoreCase: false,
+						want:       "\"n\"",
 					},
 					&litMatcher{
 						pos:        position{line: 194, col: 38, offset: 5533},
 						val:        "f",
 						ignoreCase: false,
+						want:       "\"f\"",
 					},
 					&litMatcher{
 						pos:        position{line: 194, col: 44, offset: 5539},
 						val:        "r",
 						ignoreCase: false,
+						want:       "\"r\"",
 					},
 					&litMatcher{
 						pos:        position{line: 194, col: 50, offset: 5545},
 						val:        "t",
 						ignoreCase: false,
+						want:       "\"t\"",
 					},
 					&litMatcher{
 						pos:        position{line: 194, col: 56, offset: 5551},
 						val:        "v",
 						ignoreCase: false,
+						want:       "\"v\"",
 					},
 					&litMatcher{
 						pos:        position{line: 194, col: 62, offset: 5557},
 						val:        "\\",
 						ignoreCase: false,
+						want:       "\"\\\\\"",
 					},
 				},
 			},
@@ -1285,6 +1331,7 @@ var g = &grammar{
 						pos:        position{line: 196, col: 13, offset: 5625},
 						val:        "x",
 						ignoreCase: false,
+						want:       "\"x\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 196, col: 17, offset: 5629},
@@ -1307,6 +1354,7 @@ var g = &grammar{
 						pos:        position{line: 197, col: 21, offset: 5669},
 						val:        "U",
 						ignoreCase: false,
+						want:       "\"U\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 197, col: 25, offset: 5673},
@@ -1353,6 +1401,7 @@ var g = &grammar{
 						pos:        position{line: 198, col: 22, offset: 5768},
 						val:        "u",
 						ignoreCase: false,
+						want:       "\"u\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 198, col: 26, offset: 5772},
@@ -1419,6 +1468,7 @@ var g = &grammar{
 							pos:        position{line: 204, col: 20, offset: 5898},
 							val:        "[",
 							ignoreCase: false,
+							want:       "\"[\"",
 						},
 						&zeroOrMoreExpr{
 							pos: position{line: 204, col: 26, offset: 5904},
@@ -1440,6 +1490,7 @@ var g = &grammar{
 												pos:        position{line: 204, col: 55, offset: 5933},
 												val:        "\\",
 												ignoreCase: false,
+												want:       "\"\\\\\"",
 											},
 											&ruleRefExpr{
 												pos:  position{line: 204, col: 60, offset: 5938},
@@ -1454,6 +1505,7 @@ var g = &grammar{
 							pos:        position{line: 204, col: 82, offset: 5960},
 							val:        "]",
 							ignoreCase: false,
+							want:       "\"]\"",
 						},
 						&zeroOrOneExpr{
 							pos: position{line: 204, col: 86, offset: 5964},
@@ -1461,6 +1513,7 @@ var g = &grammar{
 								pos:        position{line: 204, col: 86, offset: 5964},
 								val:        "i",
 								ignoreCase: false,
+								want:       "\"i\"",
 							},
 						},
 					},
@@ -1481,6 +1534,7 @@ var g = &grammar{
 						pos:        position{line: 209, col: 28, offset: 6098},
 						val:        "-",
 						ignoreCase: false,
+						want:       "\"-\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 209, col: 32, offset: 6102},
@@ -1507,11 +1561,13 @@ var g = &grammar{
 											pos:        position{line: 210, col: 16, offset: 6129},
 											val:        "]",
 											ignoreCase: false,
+											want:       "\"]\"",
 										},
 										&litMatcher{
 											pos:        position{line: 210, col: 22, offset: 6135},
 											val:        "\\",
 											ignoreCase: false,
+											want:       "\"\\\\\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 210, col: 29, offset: 6142},
@@ -1533,6 +1589,7 @@ var g = &grammar{
 								pos:        position{line: 210, col: 48, offset: 6161},
 								val:        "\\",
 								ignoreCase: false,
+								want:       "\"\\\\\"",
 							},
 							&ruleRefExpr{
 								pos:  position{line: 210, col: 53, offset: 6166},
@@ -1553,6 +1610,7 @@ var g = &grammar{
 						pos:        position{line: 211, col: 19, offset: 6202},
 						val:        "]",
 						ignoreCase: false,
+						want:       "\"]\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 211, col: 25, offset: 6208},
@@ -1571,6 +1629,7 @@ var g = &grammar{
 						pos:        position{line: 213, col: 22, offset: 6253},
 						val:        "p",
 						ignoreCase: false,
+						want:       "\"p\"",
 					},
 					&choiceExpr{
 						pos: position{line: 213, col: 28, offset: 6259},
@@ -1586,6 +1645,7 @@ var g = &grammar{
 										pos:        position{line: 213, col: 53, offset: 6284},
 										val:        "{",
 										ignoreCase: false,
+										want:       "\"{\"",
 									},
 									&ruleRefExpr{
 										pos:  position{line: 213, col: 57, offset: 6288},
@@ -1595,6 +1655,7 @@ var g = &grammar{
 										pos:        position{line: 213, col: 70, offset: 6301},
 										val:        "}",
 										ignoreCase: false,
+										want:       "\"}\"",
 									},
 								},
 							},
@@ -1639,6 +1700,7 @@ var g = &grammar{
 					pos:        position{line: 217, col: 14, offset: 6386},
 					val:        ".",
 					ignoreCase: false,
+					want:       "\".\"",
 				},
 			},
 		},
@@ -1655,6 +1717,7 @@ var g = &grammar{
 							pos:        position{line: 222, col: 13, offset: 6475},
 							val:        "{",
 							ignoreCase: false,
+							want:       "\"{\"",
 						},
 						&ruleRefExpr{
 							pos:  position{line: 222, col: 17, offset: 6479},
@@ -1664,6 +1727,7 @@ var g = &grammar{
 							pos:        position{line: 222, col: 22, offset: 6484},
 							val:        "}",
 							ignoreCase: false,
+							want:       "\"}\"",
 						},
 					},
 				},
@@ -1706,6 +1770,7 @@ var g = &grammar{
 									pos:        position{line: 228, col: 34, offset: 6617},
 									val:        "{",
 									ignoreCase: false,
+									want:       "\"{\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 228, col: 38, offset: 6621},
@@ -1715,6 +1780,7 @@ var g = &grammar{
 									pos:        position{line: 228, col: 43, offset: 6626},
 									val:        "}",
 									ignoreCase: false,
+									want:       "\"}\"",
 								},
 							},
 						},
@@ -1784,6 +1850,7 @@ var g = &grammar{
 				pos:        position{line: 234, col: 7, offset: 6762},
 				val:        "\n",
 				ignoreCase: false,
+				want:       "\"\\n\"",
 			},
 		},
 		{
@@ -1803,6 +1870,7 @@ var g = &grammar{
 								pos:        position{line: 235, col: 10, offset: 6778},
 								val:        ";",
 								ignoreCase: false,
+								want:       "\";\"",
 							},
 						},
 					},
@@ -2478,20 +2546,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 type charClassMatcher struct {
@@ -3293,13 +3348,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2478,6 +2478,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 type charClassMatcher struct {
@@ -3272,11 +3286,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -3284,13 +3293,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -422,6 +422,11 @@ func (b *builder) writeLitMatcher(lit *ast.LitMatcher) {
 		b.writelnf("\tval: %q,", lit.Val)
 	}
 	b.writelnf("\tignoreCase: %t,", lit.IgnoreCase)
+	ignoreCaseFlag := ""
+	if lit.IgnoreCase {
+		ignoreCaseFlag = "i"
+	}
+	b.writelnf("\twant: %q,", strconv.Quote(lit.Val)+ignoreCaseFlag)
 	b.writelnf("},")
 }
 

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -339,20 +339,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
@@ -1248,13 +1235,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -339,6 +339,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
@@ -1227,11 +1241,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 	}
 
 	// {{ end }} ==template==
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1239,13 +1248,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -357,20 +357,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
@@ -1266,13 +1253,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -357,6 +357,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 //{{ if .Nolint }} nolint: structcheck {{else}} ==template== {{ end }}
@@ -1245,11 +1259,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 	}
 
 	// {{ end }} ==template==
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1257,13 +1266,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -224,6 +224,7 @@ var g = &grammar{
 									pos:        position{line: 76, col: 11, offset: 1540},
 									val:        "(",
 									ignoreCase: false,
+									want:       "\"(\"",
 								},
 								&labeledExpr{
 									pos:   position{line: 76, col: 15, offset: 1544},
@@ -237,6 +238,7 @@ var g = &grammar{
 									pos:        position{line: 76, col: 25, offset: 1554},
 									val:        ")",
 									ignoreCase: false,
+									want:       "\")\"",
 								},
 							},
 						},
@@ -269,11 +271,13 @@ var g = &grammar{
 							pos:        position{line: 84, col: 12, offset: 1681},
 							val:        "+",
 							ignoreCase: false,
+							want:       "\"+\"",
 						},
 						&litMatcher{
 							pos:        position{line: 84, col: 18, offset: 1687},
 							val:        "-",
 							ignoreCase: false,
+							want:       "\"-\"",
 						},
 					},
 				},
@@ -292,11 +296,13 @@ var g = &grammar{
 							pos:        position{line: 89, col: 12, offset: 1760},
 							val:        "*",
 							ignoreCase: false,
+							want:       "\"*\"",
 						},
 						&litMatcher{
 							pos:        position{line: 89, col: 18, offset: 1766},
 							val:        "/",
 							ignoreCase: false,
+							want:       "\"/\"",
 						},
 					},
 				},
@@ -317,6 +323,7 @@ var g = &grammar{
 								pos:        position{line: 94, col: 12, offset: 1839},
 								val:        "-",
 								ignoreCase: false,
+								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
@@ -770,20 +777,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1592,13 +1586,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -770,6 +770,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1571,11 +1585,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1583,13 +1592,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/examples/indentation/indentation.go
+++ b/examples/indentation/indentation.go
@@ -121,6 +121,7 @@ var g = &grammar{
 							pos:        position{line: 17, col: 15, offset: 494},
 							val:        "return",
 							ignoreCase: false,
+							want:       "\"return\"",
 						},
 						&ruleRefExpr{
 							pos:  position{line: 17, col: 24, offset: 503},
@@ -179,6 +180,7 @@ var g = &grammar{
 									pos:        position{line: 20, col: 7, offset: 657},
 									val:        "if",
 									ignoreCase: false,
+									want:       "\"if\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 20, col: 12, offset: 662},
@@ -203,6 +205,7 @@ var g = &grammar{
 									pos:        position{line: 20, col: 39, offset: 689},
 									val:        ":",
 									ignoreCase: false,
+									want:       "\":\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 20, col: 43, offset: 693},
@@ -258,6 +261,7 @@ var g = &grammar{
 							pos:        position{line: 24, col: 35, offset: 880},
 							val:        "=",
 							ignoreCase: false,
+							want:       "\"=\"",
 						},
 						&zeroOrOneExpr{
 							pos: position{line: 24, col: 39, offset: 884},
@@ -429,11 +433,13 @@ var g = &grammar{
 							pos:        position{line: 36, col: 11, offset: 1684},
 							val:        "+",
 							ignoreCase: false,
+							want:       "\"+\"",
 						},
 						&litMatcher{
 							pos:        position{line: 36, col: 17, offset: 1690},
 							val:        "-",
 							ignoreCase: false,
+							want:       "\"-\"",
 						},
 					},
 				},
@@ -480,21 +486,25 @@ var g = &grammar{
 								pos:        position{line: 40, col: 20, offset: 1784},
 								val:        "\r\n",
 								ignoreCase: false,
+								want:       "\"\\r\\n\"",
 							},
 							&litMatcher{
 								pos:        position{line: 40, col: 29, offset: 1793},
 								val:        "\n\r",
 								ignoreCase: false,
+								want:       "\"\\n\\r\"",
 							},
 							&litMatcher{
 								pos:        position{line: 40, col: 38, offset: 1802},
 								val:        "\r",
 								ignoreCase: false,
+								want:       "\"\\r\"",
 							},
 							&litMatcher{
 								pos:        position{line: 40, col: 45, offset: 1809},
 								val:        "\n",
 								ignoreCase: false,
+								want:       "\"\\n\"",
 							},
 							&ruleRefExpr{
 								pos:  position{line: 40, col: 52, offset: 1816},
@@ -515,6 +525,7 @@ var g = &grammar{
 						pos:        position{line: 42, col: 11, offset: 1834},
 						val:        "//",
 						ignoreCase: false,
+						want:       "\"//\"",
 					},
 					&zeroOrMoreExpr{
 						pos: position{line: 42, col: 16, offset: 1839},
@@ -554,6 +565,7 @@ var g = &grammar{
 								pos:        position{line: 46, col: 22, offset: 1884},
 								val:        " ",
 								ignoreCase: false,
+								want:       "\" \"",
 							},
 						},
 					},
@@ -1077,20 +1089,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1899,13 +1898,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/examples/indentation/indentation.go
+++ b/examples/indentation/indentation.go
@@ -1077,6 +1077,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1878,11 +1892,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1890,13 +1899,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -124,6 +124,7 @@ var g = &grammar{
 							pos:        position{line: 25, col: 10, offset: 500},
 							val:        "{",
 							ignoreCase: false,
+							want:       "\"{\"",
 						},
 						&ruleRefExpr{
 							pos:  position{line: 25, col: 14, offset: 504},
@@ -149,6 +150,7 @@ var g = &grammar{
 											pos:        position{line: 25, col: 32, offset: 522},
 											val:        ":",
 											ignoreCase: false,
+											want:       "\":\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 25, col: 36, offset: 526},
@@ -167,6 +169,7 @@ var g = &grammar{
 														pos:        position{line: 25, col: 46, offset: 536},
 														val:        ",",
 														ignoreCase: false,
+														want:       "\",\"",
 													},
 													&ruleRefExpr{
 														pos:  position{line: 25, col: 50, offset: 540},
@@ -184,6 +187,7 @@ var g = &grammar{
 														pos:        position{line: 25, col: 61, offset: 551},
 														val:        ":",
 														ignoreCase: false,
+														want:       "\":\"",
 													},
 													&ruleRefExpr{
 														pos:  position{line: 25, col: 65, offset: 555},
@@ -204,6 +208,7 @@ var g = &grammar{
 							pos:        position{line: 25, col: 79, offset: 569},
 							val:        "}",
 							ignoreCase: false,
+							want:       "\"}\"",
 						},
 					},
 				},
@@ -222,6 +227,7 @@ var g = &grammar{
 							pos:        position{line: 40, col: 9, offset: 921},
 							val:        "[",
 							ignoreCase: false,
+							want:       "\"[\"",
 						},
 						&ruleRefExpr{
 							pos:  position{line: 40, col: 13, offset: 925},
@@ -248,6 +254,7 @@ var g = &grammar{
 														pos:        position{line: 40, col: 30, offset: 942},
 														val:        ",",
 														ignoreCase: false,
+														want:       "\",\"",
 													},
 													&ruleRefExpr{
 														pos:  position{line: 40, col: 34, offset: 946},
@@ -268,6 +275,7 @@ var g = &grammar{
 							pos:        position{line: 40, col: 48, offset: 960},
 							val:        "]",
 							ignoreCase: false,
+							want:       "\"]\"",
 						},
 					},
 				},
@@ -288,6 +296,7 @@ var g = &grammar{
 								pos:        position{line: 54, col: 10, offset: 1277},
 								val:        "-",
 								ignoreCase: false,
+								want:       "\"-\"",
 							},
 						},
 						&ruleRefExpr{
@@ -303,6 +312,7 @@ var g = &grammar{
 										pos:        position{line: 54, col: 25, offset: 1292},
 										val:        ".",
 										ignoreCase: false,
+										want:       "\".\"",
 									},
 									&oneOrMoreExpr{
 										pos: position{line: 54, col: 29, offset: 1296},
@@ -335,6 +345,7 @@ var g = &grammar{
 						pos:        position{line: 60, col: 11, offset: 1480},
 						val:        "0",
 						ignoreCase: false,
+						want:       "\"0\"",
 					},
 					&seqExpr{
 						pos: position{line: 60, col: 17, offset: 1486},
@@ -365,6 +376,7 @@ var g = &grammar{
 						pos:        position{line: 62, col: 12, offset: 1534},
 						val:        "e",
 						ignoreCase: true,
+						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
 						pos: position{line: 62, col: 17, offset: 1539},
@@ -399,6 +411,7 @@ var g = &grammar{
 							pos:        position{line: 64, col: 10, offset: 1571},
 							val:        "\"",
 							ignoreCase: false,
+							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
 							pos: position{line: 64, col: 14, offset: 1575},
@@ -427,6 +440,7 @@ var g = &grammar{
 												pos:        position{line: 64, col: 33, offset: 1594},
 												val:        "\\",
 												ignoreCase: false,
+												want:       "\"\\\\\"",
 											},
 											&ruleRefExpr{
 												pos:  position{line: 64, col: 38, offset: 1599},
@@ -441,6 +455,7 @@ var g = &grammar{
 							pos:        position{line: 64, col: 56, offset: 1617},
 							val:        "\"",
 							ignoreCase: false,
+							want:       "\"\\\"\"",
 						},
 					},
 				},
@@ -496,6 +511,7 @@ var g = &grammar{
 						pos:        position{line: 75, col: 17, offset: 1872},
 						val:        "u",
 						ignoreCase: false,
+						want:       "\"u\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 75, col: 21, offset: 1876},
@@ -562,6 +578,7 @@ var g = &grammar{
 							pos:        position{line: 83, col: 8, offset: 2001},
 							val:        "true",
 							ignoreCase: false,
+							want:       "\"true\"",
 						},
 					},
 					&actionExpr{
@@ -571,6 +588,7 @@ var g = &grammar{
 							pos:        position{line: 83, col: 38, offset: 2031},
 							val:        "false",
 							ignoreCase: false,
+							want:       "\"false\"",
 						},
 					},
 				},
@@ -586,6 +604,7 @@ var g = &grammar{
 					pos:        position{line: 85, col: 8, offset: 2071},
 					val:        "null",
 					ignoreCase: false,
+					want:       "\"null\"",
 				},
 			},
 		},
@@ -1052,20 +1071,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1874,13 +1880,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -1052,6 +1052,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1853,11 +1867,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1865,13 +1874,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -1221,6 +1221,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -2022,11 +2036,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -2034,13 +2043,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -104,6 +104,7 @@ var g = &grammar{
 														pos:        position{line: 54, col: 10, offset: 1277},
 														val:        "-",
 														ignoreCase: false,
+														want:       "\"-\"",
 													},
 												},
 												&choiceExpr{
@@ -113,6 +114,7 @@ var g = &grammar{
 															pos:        position{line: 60, col: 11, offset: 1480},
 															val:        "0",
 															ignoreCase: false,
+															want:       "\"0\"",
 														},
 														&seqExpr{
 															pos: position{line: 60, col: 17, offset: 1486},
@@ -147,6 +149,7 @@ var g = &grammar{
 																pos:        position{line: 54, col: 25, offset: 1292},
 																val:        ".",
 																ignoreCase: false,
+																want:       "\".\"",
 															},
 															&oneOrMoreExpr{
 																pos: position{line: 54, col: 29, offset: 1296},
@@ -170,6 +173,7 @@ var g = &grammar{
 																pos:        position{line: 62, col: 12, offset: 1534},
 																val:        "e",
 																ignoreCase: true,
+																want:       "\"e\"i",
 															},
 															&zeroOrOneExpr{
 																pos: position{line: 62, col: 17, offset: 1539},
@@ -207,6 +211,7 @@ var g = &grammar{
 													pos:        position{line: 64, col: 10, offset: 1571},
 													val:        "\"",
 													ignoreCase: false,
+													want:       "\"\\\"\"",
 												},
 												&zeroOrMoreExpr{
 													pos: position{line: 64, col: 14, offset: 1575},
@@ -239,6 +244,7 @@ var g = &grammar{
 																		pos:        position{line: 64, col: 33, offset: 1594},
 																		val:        "\\",
 																		ignoreCase: false,
+																		want:       "\"\\\\\"",
 																	},
 																	&choiceExpr{
 																		pos: position{line: 71, col: 18, offset: 1786},
@@ -257,6 +263,7 @@ var g = &grammar{
 																						pos:        position{line: 75, col: 17, offset: 1872},
 																						val:        "u",
 																						ignoreCase: false,
+																						want:       "\"u\"",
 																					},
 																					&charClassMatcher{
 																						pos:        position{line: 81, col: 12, offset: 1981},
@@ -299,6 +306,7 @@ var g = &grammar{
 													pos:        position{line: 64, col: 56, offset: 1617},
 													val:        "\"",
 													ignoreCase: false,
+													want:       "\"\\\"\"",
 												},
 											},
 										},
@@ -310,6 +318,7 @@ var g = &grammar{
 											pos:        position{line: 83, col: 8, offset: 2001},
 											val:        "true",
 											ignoreCase: false,
+											want:       "\"true\"",
 										},
 									},
 									&actionExpr{
@@ -319,6 +328,7 @@ var g = &grammar{
 											pos:        position{line: 83, col: 38, offset: 2031},
 											val:        "false",
 											ignoreCase: false,
+											want:       "\"false\"",
 										},
 									},
 									&actionExpr{
@@ -328,6 +338,7 @@ var g = &grammar{
 											pos:        position{line: 85, col: 8, offset: 2071},
 											val:        "null",
 											ignoreCase: false,
+											want:       "\"null\"",
 										},
 									},
 								},
@@ -360,6 +371,7 @@ var g = &grammar{
 							pos:        position{line: 25, col: 10, offset: 500},
 							val:        "{",
 							ignoreCase: false,
+							want:       "\"{\"",
 						},
 						&zeroOrMoreExpr{
 							pos: position{line: 87, col: 18, offset: 2118},
@@ -389,6 +401,7 @@ var g = &grammar{
 														pos:        position{line: 64, col: 10, offset: 1571},
 														val:        "\"",
 														ignoreCase: false,
+														want:       "\"\\\"\"",
 													},
 													&zeroOrMoreExpr{
 														pos: position{line: 64, col: 14, offset: 1575},
@@ -421,6 +434,7 @@ var g = &grammar{
 																			pos:        position{line: 64, col: 33, offset: 1594},
 																			val:        "\\",
 																			ignoreCase: false,
+																			want:       "\"\\\\\"",
 																		},
 																		&choiceExpr{
 																			pos: position{line: 71, col: 18, offset: 1786},
@@ -439,6 +453,7 @@ var g = &grammar{
 																							pos:        position{line: 75, col: 17, offset: 1872},
 																							val:        "u",
 																							ignoreCase: false,
+																							want:       "\"u\"",
 																						},
 																						&charClassMatcher{
 																							pos:        position{line: 81, col: 12, offset: 1981},
@@ -481,6 +496,7 @@ var g = &grammar{
 														pos:        position{line: 64, col: 56, offset: 1617},
 														val:        "\"",
 														ignoreCase: false,
+														want:       "\"\\\"\"",
 													},
 												},
 											},
@@ -499,6 +515,7 @@ var g = &grammar{
 											pos:        position{line: 25, col: 32, offset: 522},
 											val:        ":",
 											ignoreCase: false,
+											want:       "\":\"",
 										},
 										&zeroOrMoreExpr{
 											pos: position{line: 87, col: 18, offset: 2118},
@@ -523,6 +540,7 @@ var g = &grammar{
 														pos:        position{line: 25, col: 46, offset: 536},
 														val:        ",",
 														ignoreCase: false,
+														want:       "\",\"",
 													},
 													&zeroOrMoreExpr{
 														pos: position{line: 87, col: 18, offset: 2118},
@@ -544,6 +562,7 @@ var g = &grammar{
 																	pos:        position{line: 64, col: 10, offset: 1571},
 																	val:        "\"",
 																	ignoreCase: false,
+																	want:       "\"\\\"\"",
 																},
 																&zeroOrMoreExpr{
 																	pos: position{line: 64, col: 14, offset: 1575},
@@ -576,6 +595,7 @@ var g = &grammar{
 																						pos:        position{line: 64, col: 33, offset: 1594},
 																						val:        "\\",
 																						ignoreCase: false,
+																						want:       "\"\\\\\"",
 																					},
 																					&choiceExpr{
 																						pos: position{line: 71, col: 18, offset: 1786},
@@ -594,6 +614,7 @@ var g = &grammar{
 																										pos:        position{line: 75, col: 17, offset: 1872},
 																										val:        "u",
 																										ignoreCase: false,
+																										want:       "\"u\"",
 																									},
 																									&charClassMatcher{
 																										pos:        position{line: 81, col: 12, offset: 1981},
@@ -636,6 +657,7 @@ var g = &grammar{
 																	pos:        position{line: 64, col: 56, offset: 1617},
 																	val:        "\"",
 																	ignoreCase: false,
+																	want:       "\"\\\"\"",
 																},
 															},
 														},
@@ -654,6 +676,7 @@ var g = &grammar{
 														pos:        position{line: 25, col: 61, offset: 551},
 														val:        ":",
 														ignoreCase: false,
+														want:       "\":\"",
 													},
 													&zeroOrMoreExpr{
 														pos: position{line: 87, col: 18, offset: 2118},
@@ -680,6 +703,7 @@ var g = &grammar{
 							pos:        position{line: 25, col: 79, offset: 569},
 							val:        "}",
 							ignoreCase: false,
+							want:       "\"}\"",
 						},
 					},
 				},
@@ -698,6 +722,7 @@ var g = &grammar{
 							pos:        position{line: 40, col: 9, offset: 921},
 							val:        "[",
 							ignoreCase: false,
+							want:       "\"[\"",
 						},
 						&zeroOrMoreExpr{
 							pos: position{line: 87, col: 18, offset: 2118},
@@ -730,6 +755,7 @@ var g = &grammar{
 														pos:        position{line: 40, col: 30, offset: 942},
 														val:        ",",
 														ignoreCase: false,
+														want:       "\",\"",
 													},
 													&zeroOrMoreExpr{
 														pos: position{line: 87, col: 18, offset: 2118},
@@ -756,6 +782,7 @@ var g = &grammar{
 							pos:        position{line: 40, col: 48, offset: 960},
 							val:        "]",
 							ignoreCase: false,
+							want:       "\"]\"",
 						},
 					},
 				},
@@ -1221,20 +1248,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -2043,13 +2057,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -980,6 +980,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1589,11 +1603,6 @@ func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1601,13 +1610,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -123,6 +123,7 @@ var g = &grammar{
 							pos:        position{line: 25, col: 10, offset: 500},
 							val:        "{",
 							ignoreCase: false,
+							want:       "\"{\"",
 						},
 						&ruleRefExpr{
 							pos:  position{line: 25, col: 14, offset: 504},
@@ -148,6 +149,7 @@ var g = &grammar{
 											pos:        position{line: 25, col: 32, offset: 522},
 											val:        ":",
 											ignoreCase: false,
+											want:       "\":\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 25, col: 36, offset: 526},
@@ -166,6 +168,7 @@ var g = &grammar{
 														pos:        position{line: 25, col: 46, offset: 536},
 														val:        ",",
 														ignoreCase: false,
+														want:       "\",\"",
 													},
 													&ruleRefExpr{
 														pos:  position{line: 25, col: 50, offset: 540},
@@ -183,6 +186,7 @@ var g = &grammar{
 														pos:        position{line: 25, col: 61, offset: 551},
 														val:        ":",
 														ignoreCase: false,
+														want:       "\":\"",
 													},
 													&ruleRefExpr{
 														pos:  position{line: 25, col: 65, offset: 555},
@@ -203,6 +207,7 @@ var g = &grammar{
 							pos:        position{line: 25, col: 79, offset: 569},
 							val:        "}",
 							ignoreCase: false,
+							want:       "\"}\"",
 						},
 					},
 				},
@@ -221,6 +226,7 @@ var g = &grammar{
 							pos:        position{line: 40, col: 9, offset: 921},
 							val:        "[",
 							ignoreCase: false,
+							want:       "\"[\"",
 						},
 						&ruleRefExpr{
 							pos:  position{line: 40, col: 13, offset: 925},
@@ -247,6 +253,7 @@ var g = &grammar{
 														pos:        position{line: 40, col: 30, offset: 942},
 														val:        ",",
 														ignoreCase: false,
+														want:       "\",\"",
 													},
 													&ruleRefExpr{
 														pos:  position{line: 40, col: 34, offset: 946},
@@ -267,6 +274,7 @@ var g = &grammar{
 							pos:        position{line: 40, col: 48, offset: 960},
 							val:        "]",
 							ignoreCase: false,
+							want:       "\"]\"",
 						},
 					},
 				},
@@ -287,6 +295,7 @@ var g = &grammar{
 								pos:        position{line: 54, col: 10, offset: 1277},
 								val:        "-",
 								ignoreCase: false,
+								want:       "\"-\"",
 							},
 						},
 						&ruleRefExpr{
@@ -302,6 +311,7 @@ var g = &grammar{
 										pos:        position{line: 54, col: 25, offset: 1292},
 										val:        ".",
 										ignoreCase: false,
+										want:       "\".\"",
 									},
 									&oneOrMoreExpr{
 										pos: position{line: 54, col: 29, offset: 1296},
@@ -334,6 +344,7 @@ var g = &grammar{
 						pos:        position{line: 60, col: 11, offset: 1480},
 						val:        "0",
 						ignoreCase: false,
+						want:       "\"0\"",
 					},
 					&seqExpr{
 						pos: position{line: 60, col: 17, offset: 1486},
@@ -364,6 +375,7 @@ var g = &grammar{
 						pos:        position{line: 62, col: 12, offset: 1534},
 						val:        "e",
 						ignoreCase: true,
+						want:       "\"e\"i",
 					},
 					&zeroOrOneExpr{
 						pos: position{line: 62, col: 17, offset: 1539},
@@ -399,6 +411,7 @@ var g = &grammar{
 							pos:        position{line: 64, col: 10, offset: 1571},
 							val:        "\"",
 							ignoreCase: false,
+							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
 							pos: position{line: 64, col: 14, offset: 1575},
@@ -427,6 +440,7 @@ var g = &grammar{
 												pos:        position{line: 64, col: 33, offset: 1594},
 												val:        "\\",
 												ignoreCase: false,
+												want:       "\"\\\\\"",
 											},
 											&ruleRefExpr{
 												pos:  position{line: 64, col: 38, offset: 1599},
@@ -441,6 +455,7 @@ var g = &grammar{
 							pos:        position{line: 64, col: 56, offset: 1617},
 							val:        "\"",
 							ignoreCase: false,
+							want:       "\"\\\"\"",
 						},
 					},
 				},
@@ -498,6 +513,7 @@ var g = &grammar{
 						pos:        position{line: 75, col: 17, offset: 1872},
 						val:        "u",
 						ignoreCase: false,
+						want:       "\"u\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 75, col: 21, offset: 1876},
@@ -567,6 +583,7 @@ var g = &grammar{
 							pos:        position{line: 83, col: 8, offset: 2001},
 							val:        "true",
 							ignoreCase: false,
+							want:       "\"true\"",
 						},
 					},
 					&actionExpr{
@@ -576,6 +593,7 @@ var g = &grammar{
 							pos:        position{line: 83, col: 38, offset: 2031},
 							val:        "false",
 							ignoreCase: false,
+							want:       "\"false\"",
 						},
 					},
 				},
@@ -591,6 +609,7 @@ var g = &grammar{
 					pos:        position{line: 85, col: 8, offset: 2071},
 					val:        "null",
 					ignoreCase: false,
+					want:       "\"null\"",
 				},
 			},
 		},
@@ -980,20 +999,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1610,13 +1616,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/pigeon.go
+++ b/pigeon.go
@@ -214,6 +214,7 @@ var g = &grammar{
 											pos:        position{line: 43, col: 50, offset: 1041},
 											val:        "//{",
 											ignoreCase: false,
+											want:       "\"//{\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 43, col: 56, offset: 1047},
@@ -231,6 +232,7 @@ var g = &grammar{
 											pos:        position{line: 43, col: 69, offset: 1060},
 											val:        "}",
 											ignoreCase: false,
+											want:       "\"}\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 43, col: 73, offset: 1064},
@@ -281,6 +283,7 @@ var g = &grammar{
 											pos:        position{line: 58, col: 43, offset: 1525},
 											val:        ",",
 											ignoreCase: false,
+											want:       "\",\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 58, col: 47, offset: 1529},
@@ -331,6 +334,7 @@ var g = &grammar{
 											pos:        position{line: 67, col: 41, offset: 1903},
 											val:        "/",
 											ignoreCase: false,
+											want:       "\"/\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 67, col: 45, offset: 1907},
@@ -458,6 +462,7 @@ var g = &grammar{
 									pos:        position{line: 109, col: 35, offset: 3046},
 									val:        ":",
 									ignoreCase: false,
+									want:       "\":\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 109, col: 39, offset: 3050},
@@ -540,11 +545,13 @@ var g = &grammar{
 							pos:        position{line: 130, col: 16, offset: 3609},
 							val:        "&",
 							ignoreCase: false,
+							want:       "\"&\"",
 						},
 						&litMatcher{
 							pos:        position{line: 130, col: 22, offset: 3615},
 							val:        "!",
 							ignoreCase: false,
+							want:       "\"!\"",
 						},
 					},
 				},
@@ -605,16 +612,19 @@ var g = &grammar{
 							pos:        position{line: 155, col: 16, offset: 4257},
 							val:        "?",
 							ignoreCase: false,
+							want:       "\"?\"",
 						},
 						&litMatcher{
 							pos:        position{line: 155, col: 22, offset: 4263},
 							val:        "*",
 							ignoreCase: false,
+							want:       "\"*\"",
 						},
 						&litMatcher{
 							pos:        position{line: 155, col: 28, offset: 4269},
 							val:        "+",
 							ignoreCase: false,
+							want:       "\"+\"",
 						},
 					},
 				},
@@ -656,6 +666,7 @@ var g = &grammar{
 									pos:        position{line: 159, col: 93, offset: 4405},
 									val:        "(",
 									ignoreCase: false,
+									want:       "\"(\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 159, col: 97, offset: 4409},
@@ -677,6 +688,7 @@ var g = &grammar{
 									pos:        position{line: 159, col: 119, offset: 4431},
 									val:        ")",
 									ignoreCase: false,
+									want:       "\")\"",
 								},
 							},
 						},
@@ -783,16 +795,19 @@ var g = &grammar{
 							pos:        position{line: 187, col: 20, offset: 5155},
 							val:        "#",
 							ignoreCase: false,
+							want:       "\"#\"",
 						},
 						&litMatcher{
 							pos:        position{line: 187, col: 26, offset: 5161},
 							val:        "&",
 							ignoreCase: false,
+							want:       "\"&\"",
 						},
 						&litMatcher{
 							pos:        position{line: 187, col: 32, offset: 5167},
 							val:        "!",
 							ignoreCase: false,
+							want:       "\"!\"",
 						},
 					},
 				},
@@ -808,21 +823,25 @@ var g = &grammar{
 						pos:        position{line: 191, col: 13, offset: 5223},
 						val:        "=",
 						ignoreCase: false,
+						want:       "\"=\"",
 					},
 					&litMatcher{
 						pos:        position{line: 191, col: 19, offset: 5229},
 						val:        "<-",
 						ignoreCase: false,
+						want:       "\"<-\"",
 					},
 					&litMatcher{
 						pos:        position{line: 191, col: 26, offset: 5236},
 						val:        "←",
 						ignoreCase: false,
+						want:       "\"←\"",
 					},
 					&litMatcher{
 						pos:        position{line: 191, col: 37, offset: 5247},
 						val:        "⟵",
 						ignoreCase: false,
+						want:       "\"⟵\"",
 					},
 				},
 			},
@@ -861,6 +880,7 @@ var g = &grammar{
 						pos:        position{line: 195, col: 20, offset: 5344},
 						val:        "/*",
 						ignoreCase: false,
+						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
 						pos: position{line: 195, col: 25, offset: 5349},
@@ -873,6 +893,7 @@ var g = &grammar{
 										pos:        position{line: 195, col: 28, offset: 5352},
 										val:        "*/",
 										ignoreCase: false,
+										want:       "\"*/\"",
 									},
 								},
 								&ruleRefExpr{
@@ -886,6 +907,7 @@ var g = &grammar{
 						pos:        position{line: 195, col: 47, offset: 5371},
 						val:        "*/",
 						ignoreCase: false,
+						want:       "\"*/\"",
 					},
 				},
 			},
@@ -900,6 +922,7 @@ var g = &grammar{
 						pos:        position{line: 196, col: 36, offset: 5413},
 						val:        "/*",
 						ignoreCase: false,
+						want:       "\"/*\"",
 					},
 					&zeroOrMoreExpr{
 						pos: position{line: 196, col: 41, offset: 5418},
@@ -915,6 +938,7 @@ var g = &grammar{
 												pos:        position{line: 196, col: 46, offset: 5423},
 												val:        "*/",
 												ignoreCase: false,
+												want:       "\"*/\"",
 											},
 											&ruleRefExpr{
 												pos:  position{line: 196, col: 53, offset: 5430},
@@ -934,6 +958,7 @@ var g = &grammar{
 						pos:        position{line: 196, col: 73, offset: 5450},
 						val:        "*/",
 						ignoreCase: false,
+						want:       "\"*/\"",
 					},
 				},
 			},
@@ -950,12 +975,14 @@ var g = &grammar{
 							pos:        position{line: 197, col: 23, offset: 5479},
 							val:        "//{",
 							ignoreCase: false,
+							want:       "\"//{\"",
 						},
 					},
 					&litMatcher{
 						pos:        position{line: 197, col: 30, offset: 5486},
 						val:        "//",
 						ignoreCase: false,
+						want:       "\"//\"",
 					},
 					&zeroOrMoreExpr{
 						pos: position{line: 197, col: 35, offset: 5491},
@@ -1077,6 +1104,7 @@ var g = &grammar{
 									pos:        position{line: 213, col: 39, offset: 5984},
 									val:        "i",
 									ignoreCase: false,
+									want:       "\"i\"",
 								},
 							},
 						},
@@ -1103,6 +1131,7 @@ var g = &grammar{
 											pos:        position{line: 226, col: 19, offset: 6403},
 											val:        "\"",
 											ignoreCase: false,
+											want:       "\"\\\"\"",
 										},
 										&zeroOrMoreExpr{
 											pos: position{line: 226, col: 23, offset: 6407},
@@ -1115,6 +1144,7 @@ var g = &grammar{
 											pos:        position{line: 226, col: 41, offset: 6425},
 											val:        "\"",
 											ignoreCase: false,
+											want:       "\"\\\"\"",
 										},
 									},
 								},
@@ -1125,6 +1155,7 @@ var g = &grammar{
 											pos:        position{line: 226, col: 47, offset: 6431},
 											val:        "'",
 											ignoreCase: false,
+											want:       "\"'\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 226, col: 51, offset: 6435},
@@ -1134,6 +1165,7 @@ var g = &grammar{
 											pos:        position{line: 226, col: 68, offset: 6452},
 											val:        "'",
 											ignoreCase: false,
+											want:       "\"'\"",
 										},
 									},
 								},
@@ -1144,6 +1176,7 @@ var g = &grammar{
 											pos:        position{line: 226, col: 74, offset: 6458},
 											val:        "`",
 											ignoreCase: false,
+											want:       "\"`\"",
 										},
 										&zeroOrMoreExpr{
 											pos: position{line: 226, col: 78, offset: 6462},
@@ -1156,6 +1189,7 @@ var g = &grammar{
 											pos:        position{line: 226, col: 93, offset: 6477},
 											val:        "`",
 											ignoreCase: false,
+											want:       "\"`\"",
 										},
 									},
 								},
@@ -1175,6 +1209,7 @@ var g = &grammar{
 											pos:        position{line: 228, col: 9, offset: 6554},
 											val:        "\"",
 											ignoreCase: false,
+											want:       "\"\\\"\"",
 										},
 										&zeroOrMoreExpr{
 											pos: position{line: 228, col: 13, offset: 6558},
@@ -1205,6 +1240,7 @@ var g = &grammar{
 											pos:        position{line: 228, col: 51, offset: 6596},
 											val:        "'",
 											ignoreCase: false,
+											want:       "\"'\"",
 										},
 										&zeroOrOneExpr{
 											pos: position{line: 228, col: 55, offset: 6600},
@@ -1235,6 +1271,7 @@ var g = &grammar{
 											pos:        position{line: 228, col: 91, offset: 6636},
 											val:        "`",
 											ignoreCase: false,
+											want:       "\"`\"",
 										},
 										&zeroOrMoreExpr{
 											pos: position{line: 228, col: 95, offset: 6640},
@@ -1273,11 +1310,13 @@ var g = &grammar{
 											pos:        position{line: 232, col: 23, offset: 6781},
 											val:        "\"",
 											ignoreCase: false,
+											want:       "\"\\\"\"",
 										},
 										&litMatcher{
 											pos:        position{line: 232, col: 29, offset: 6787},
 											val:        "\\",
 											ignoreCase: false,
+											want:       "\"\\\\\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 232, col: 36, offset: 6794},
@@ -1299,6 +1338,7 @@ var g = &grammar{
 								pos:        position{line: 232, col: 55, offset: 6813},
 								val:        "\\",
 								ignoreCase: false,
+								want:       "\"\\\\\"",
 							},
 							&ruleRefExpr{
 								pos:  position{line: 232, col: 60, offset: 6818},
@@ -1327,11 +1367,13 @@ var g = &grammar{
 											pos:        position{line: 233, col: 23, offset: 6861},
 											val:        "'",
 											ignoreCase: false,
+											want:       "\"'\"",
 										},
 										&litMatcher{
 											pos:        position{line: 233, col: 29, offset: 6867},
 											val:        "\\",
 											ignoreCase: false,
+											want:       "\"\\\\\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 233, col: 36, offset: 6874},
@@ -1353,6 +1395,7 @@ var g = &grammar{
 								pos:        position{line: 233, col: 55, offset: 6893},
 								val:        "\\",
 								ignoreCase: false,
+								want:       "\"\\\\\"",
 							},
 							&ruleRefExpr{
 								pos:  position{line: 233, col: 60, offset: 6898},
@@ -1375,6 +1418,7 @@ var g = &grammar{
 							pos:        position{line: 234, col: 18, offset: 6936},
 							val:        "`",
 							ignoreCase: false,
+							want:       "\"`\"",
 						},
 					},
 					&ruleRefExpr{
@@ -1397,6 +1441,7 @@ var g = &grammar{
 								pos:        position{line: 236, col: 24, offset: 6977},
 								val:        "\"",
 								ignoreCase: false,
+								want:       "\"\\\"\"",
 							},
 							&ruleRefExpr{
 								pos:  position{line: 236, col: 30, offset: 6983},
@@ -1441,6 +1486,7 @@ var g = &grammar{
 								pos:        position{line: 240, col: 24, offset: 7123},
 								val:        "'",
 								ignoreCase: false,
+								want:       "\"'\"",
 							},
 							&ruleRefExpr{
 								pos:  position{line: 240, col: 30, offset: 7129},
@@ -1511,41 +1557,49 @@ var g = &grammar{
 						pos:        position{line: 246, col: 20, offset: 7375},
 						val:        "a",
 						ignoreCase: false,
+						want:       "\"a\"",
 					},
 					&litMatcher{
 						pos:        position{line: 246, col: 26, offset: 7381},
 						val:        "b",
 						ignoreCase: false,
+						want:       "\"b\"",
 					},
 					&litMatcher{
 						pos:        position{line: 246, col: 32, offset: 7387},
 						val:        "n",
 						ignoreCase: false,
+						want:       "\"n\"",
 					},
 					&litMatcher{
 						pos:        position{line: 246, col: 38, offset: 7393},
 						val:        "f",
 						ignoreCase: false,
+						want:       "\"f\"",
 					},
 					&litMatcher{
 						pos:        position{line: 246, col: 44, offset: 7399},
 						val:        "r",
 						ignoreCase: false,
+						want:       "\"r\"",
 					},
 					&litMatcher{
 						pos:        position{line: 246, col: 50, offset: 7405},
 						val:        "t",
 						ignoreCase: false,
+						want:       "\"t\"",
 					},
 					&litMatcher{
 						pos:        position{line: 246, col: 56, offset: 7411},
 						val:        "v",
 						ignoreCase: false,
+						want:       "\"v\"",
 					},
 					&litMatcher{
 						pos:        position{line: 246, col: 62, offset: 7417},
 						val:        "\\",
 						ignoreCase: false,
+						want:       "\"\\\\\"",
 					},
 				},
 			},
@@ -1619,6 +1673,7 @@ var g = &grammar{
 								pos:        position{line: 251, col: 13, offset: 7584},
 								val:        "x",
 								ignoreCase: false,
+								want:       "\"x\"",
 							},
 							&ruleRefExpr{
 								pos:  position{line: 251, col: 17, offset: 7588},
@@ -1640,6 +1695,7 @@ var g = &grammar{
 									pos:        position{line: 252, col: 7, offset: 7612},
 									val:        "x",
 									ignoreCase: false,
+									want:       "\"x\"",
 								},
 								&choiceExpr{
 									pos: position{line: 252, col: 13, offset: 7618},
@@ -1680,6 +1736,7 @@ var g = &grammar{
 									pos:        position{line: 256, col: 5, offset: 7730},
 									val:        "U",
 									ignoreCase: false,
+									want:       "\"U\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 256, col: 9, offset: 7734},
@@ -1726,6 +1783,7 @@ var g = &grammar{
 									pos:        position{line: 259, col: 7, offset: 7899},
 									val:        "U",
 									ignoreCase: false,
+									want:       "\"U\"",
 								},
 								&choiceExpr{
 									pos: position{line: 259, col: 13, offset: 7905},
@@ -1766,6 +1824,7 @@ var g = &grammar{
 									pos:        position{line: 263, col: 5, offset: 8014},
 									val:        "u",
 									ignoreCase: false,
+									want:       "\"u\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 263, col: 9, offset: 8018},
@@ -1796,6 +1855,7 @@ var g = &grammar{
 									pos:        position{line: 266, col: 7, offset: 8147},
 									val:        "u",
 									ignoreCase: false,
+									want:       "\"u\"",
 								},
 								&choiceExpr{
 									pos: position{line: 266, col: 13, offset: 8153},
@@ -1869,6 +1929,7 @@ var g = &grammar{
 									pos:        position{line: 274, col: 20, offset: 8325},
 									val:        "[",
 									ignoreCase: false,
+									want:       "\"[\"",
 								},
 								&zeroOrMoreExpr{
 									pos: position{line: 274, col: 24, offset: 8329},
@@ -1890,6 +1951,7 @@ var g = &grammar{
 														pos:        position{line: 274, col: 55, offset: 8360},
 														val:        "\\",
 														ignoreCase: false,
+														want:       "\"\\\\\"",
 													},
 													&ruleRefExpr{
 														pos:  position{line: 274, col: 60, offset: 8365},
@@ -1904,6 +1966,7 @@ var g = &grammar{
 									pos:        position{line: 274, col: 82, offset: 8387},
 									val:        "]",
 									ignoreCase: false,
+									want:       "\"]\"",
 								},
 								&zeroOrOneExpr{
 									pos: position{line: 274, col: 86, offset: 8391},
@@ -1911,6 +1974,7 @@ var g = &grammar{
 										pos:        position{line: 274, col: 86, offset: 8391},
 										val:        "i",
 										ignoreCase: false,
+										want:       "\"i\"",
 									},
 								},
 							},
@@ -1926,6 +1990,7 @@ var g = &grammar{
 									pos:        position{line: 278, col: 5, offset: 8498},
 									val:        "[",
 									ignoreCase: false,
+									want:       "\"[\"",
 								},
 								&zeroOrMoreExpr{
 									pos: position{line: 278, col: 9, offset: 8502},
@@ -1979,6 +2044,7 @@ var g = &grammar{
 						pos:        position{line: 282, col: 28, offset: 8674},
 						val:        "-",
 						ignoreCase: false,
+						want:       "\"-\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 282, col: 32, offset: 8678},
@@ -2005,11 +2071,13 @@ var g = &grammar{
 											pos:        position{line: 283, col: 16, offset: 8705},
 											val:        "]",
 											ignoreCase: false,
+											want:       "\"]\"",
 										},
 										&litMatcher{
 											pos:        position{line: 283, col: 22, offset: 8711},
 											val:        "\\",
 											ignoreCase: false,
+											want:       "\"\\\\\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 283, col: 29, offset: 8718},
@@ -2031,6 +2099,7 @@ var g = &grammar{
 								pos:        position{line: 283, col: 48, offset: 8737},
 								val:        "\\",
 								ignoreCase: false,
+								want:       "\"\\\\\"",
 							},
 							&ruleRefExpr{
 								pos:  position{line: 283, col: 53, offset: 8742},
@@ -2054,6 +2123,7 @@ var g = &grammar{
 								pos:        position{line: 284, col: 21, offset: 8780},
 								val:        "]",
 								ignoreCase: false,
+								want:       "\"]\"",
 							},
 							&ruleRefExpr{
 								pos:  position{line: 284, col: 27, offset: 8786},
@@ -2073,6 +2143,7 @@ var g = &grammar{
 										pos:        position{line: 285, col: 8, offset: 8816},
 										val:        "p",
 										ignoreCase: false,
+										want:       "\"p\"",
 									},
 								},
 								&choiceExpr{
@@ -2108,6 +2179,7 @@ var g = &grammar{
 						pos:        position{line: 289, col: 22, offset: 8930},
 						val:        "p",
 						ignoreCase: false,
+						want:       "\"p\"",
 					},
 					&choiceExpr{
 						pos: position{line: 290, col: 7, offset: 8942},
@@ -2128,6 +2200,7 @@ var g = &grammar{
 												pos:        position{line: 291, col: 8, offset: 8972},
 												val:        "{",
 												ignoreCase: false,
+												want:       "\"{\"",
 											},
 										},
 										&choiceExpr{
@@ -2160,6 +2233,7 @@ var g = &grammar{
 											pos:        position{line: 292, col: 7, offset: 9068},
 											val:        "{",
 											ignoreCase: false,
+											want:       "\"{\"",
 										},
 										&labeledExpr{
 											pos:   position{line: 292, col: 11, offset: 9072},
@@ -2173,6 +2247,7 @@ var g = &grammar{
 											pos:        position{line: 292, col: 32, offset: 9093},
 											val:        "}",
 											ignoreCase: false,
+											want:       "\"}\"",
 										},
 									},
 								},
@@ -2187,6 +2262,7 @@ var g = &grammar{
 											pos:        position{line: 298, col: 7, offset: 9270},
 											val:        "{",
 											ignoreCase: false,
+											want:       "\"{\"",
 										},
 										&ruleRefExpr{
 											pos:  position{line: 298, col: 11, offset: 9274},
@@ -2199,6 +2275,7 @@ var g = &grammar{
 													pos:        position{line: 298, col: 28, offset: 9291},
 													val:        "]",
 													ignoreCase: false,
+													want:       "\"]\"",
 												},
 												&ruleRefExpr{
 													pos:  position{line: 298, col: 34, offset: 9297},
@@ -2239,6 +2316,7 @@ var g = &grammar{
 					pos:        position{line: 304, col: 14, offset: 9439},
 					val:        ".",
 					ignoreCase: false,
+					want:       "\".\"",
 				},
 			},
 		},
@@ -2258,11 +2336,13 @@ var g = &grammar{
 									pos:        position{line: 309, col: 13, offset: 9528},
 									val:        "%",
 									ignoreCase: false,
+									want:       "\"%\"",
 								},
 								&litMatcher{
 									pos:        position{line: 309, col: 17, offset: 9532},
 									val:        "{",
 									ignoreCase: false,
+									want:       "\"{\"",
 								},
 								&labeledExpr{
 									pos:   position{line: 309, col: 21, offset: 9536},
@@ -2276,6 +2356,7 @@ var g = &grammar{
 									pos:        position{line: 309, col: 42, offset: 9557},
 									val:        "}",
 									ignoreCase: false,
+									want:       "\"}\"",
 								},
 							},
 						},
@@ -2290,11 +2371,13 @@ var g = &grammar{
 									pos:        position{line: 313, col: 5, offset: 9665},
 									val:        "%",
 									ignoreCase: false,
+									want:       "\"%\"",
 								},
 								&litMatcher{
 									pos:        position{line: 313, col: 9, offset: 9669},
 									val:        "{",
 									ignoreCase: false,
+									want:       "\"{\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 313, col: 13, offset: 9673},
@@ -2326,6 +2409,7 @@ var g = &grammar{
 									pos:        position{line: 317, col: 13, offset: 9773},
 									val:        "{",
 									ignoreCase: false,
+									want:       "\"{\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 317, col: 17, offset: 9777},
@@ -2335,6 +2419,7 @@ var g = &grammar{
 									pos:        position{line: 317, col: 22, offset: 9782},
 									val:        "}",
 									ignoreCase: false,
+									want:       "\"}\"",
 								},
 							},
 						},
@@ -2349,6 +2434,7 @@ var g = &grammar{
 									pos:        position{line: 321, col: 5, offset: 9881},
 									val:        "{",
 									ignoreCase: false,
+									want:       "\"{\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 321, col: 9, offset: 9885},
@@ -2410,6 +2496,7 @@ var g = &grammar{
 									pos:        position{line: 325, col: 44, offset: 10000},
 									val:        "{",
 									ignoreCase: false,
+									want:       "\"{\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 325, col: 48, offset: 10004},
@@ -2419,6 +2506,7 @@ var g = &grammar{
 									pos:        position{line: 325, col: 53, offset: 10009},
 									val:        "}",
 									ignoreCase: false,
+									want:       "\"}\"",
 								},
 							},
 						},
@@ -2488,6 +2576,7 @@ var g = &grammar{
 				pos:        position{line: 331, col: 7, offset: 10145},
 				val:        "\n",
 				ignoreCase: false,
+				want:       "\"\\n\"",
 			},
 		},
 		{
@@ -2507,6 +2596,7 @@ var g = &grammar{
 								pos:        position{line: 332, col: 10, offset: 10161},
 								val:        ";",
 								ignoreCase: false,
+								want:       "\";\"",
 							},
 						},
 					},
@@ -3437,20 +3527,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -4259,13 +4336,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/pigeon.go
+++ b/pigeon.go
@@ -3437,6 +3437,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -4238,11 +4252,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -4250,13 +4259,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -35,6 +35,7 @@ var g = &grammar{
 								pos:        position{line: 17, col: 6, offset: 159},
 								val:        "a",
 								ignoreCase: false,
+								want:       "\"a\"",
 							},
 						},
 						&actionExpr{
@@ -46,6 +47,7 @@ var g = &grammar{
 									pos:        position{line: 19, col: 6, offset: 179},
 									val:        "c",
 									ignoreCase: false,
+									want:       "\"c\"",
 								},
 							},
 						},
@@ -74,6 +76,7 @@ var g = &grammar{
 								pos:        position{line: 18, col: 6, offset: 169},
 								val:        "b",
 								ignoreCase: false,
+								want:       "\"b\"",
 							},
 						},
 						&actionExpr{
@@ -85,6 +88,7 @@ var g = &grammar{
 									pos:        position{line: 19, col: 6, offset: 179},
 									val:        "c",
 									ignoreCase: false,
+									want:       "\"c\"",
 								},
 							},
 						},
@@ -116,6 +120,7 @@ var g = &grammar{
 									pos:        position{line: 19, col: 6, offset: 179},
 									val:        "c",
 									ignoreCase: false,
+									want:       "\"c\"",
 								},
 							},
 						},
@@ -141,6 +146,7 @@ var g = &grammar{
 						pos:        position{line: 19, col: 6, offset: 179},
 						val:        "c",
 						ignoreCase: false,
+						want:       "\"c\"",
 					},
 				},
 			},
@@ -539,20 +545,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1361,13 +1354,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -539,6 +539,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1340,11 +1354,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1352,13 +1361,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -485,6 +485,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1286,11 +1300,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1298,13 +1307,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -485,20 +485,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1307,13 +1294,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/emptystate/emptystate.go
+++ b/test/emptystate/emptystate.go
@@ -67,6 +67,7 @@ var g = &grammar{
 					pos:        position{line: 10, col: 6, offset: 99},
 					val:        "a",
 					ignoreCase: false,
+					want:       "\"a\"",
 				},
 			},
 		},
@@ -80,6 +81,7 @@ var g = &grammar{
 						pos:        position{line: 16, col: 6, offset: 229},
 						val:        "b",
 						ignoreCase: false,
+						want:       "\"b\"",
 					},
 					&stateCodeExpr{
 						pos: position{line: 17, col: 3, offset: 235},
@@ -98,6 +100,7 @@ var g = &grammar{
 					pos:        position{line: 23, col: 6, offset: 342},
 					val:        "c",
 					ignoreCase: false,
+					want:       "\"c\"",
 				},
 			},
 		},
@@ -111,6 +114,7 @@ var g = &grammar{
 						pos:        position{line: 29, col: 6, offset: 489},
 						val:        "d",
 						ignoreCase: false,
+						want:       "\"d\"",
 					},
 					&stateCodeExpr{
 						pos: position{line: 30, col: 3, offset: 495},
@@ -129,6 +133,7 @@ var g = &grammar{
 					pos:        position{line: 36, col: 6, offset: 652},
 					val:        "e",
 					ignoreCase: false,
+					want:       "\"e\"",
 				},
 			},
 		},
@@ -540,20 +545,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1362,13 +1354,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/emptystate/emptystate.go
+++ b/test/emptystate/emptystate.go
@@ -540,6 +540,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1341,11 +1355,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1353,13 +1362,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -900,6 +900,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1701,11 +1715,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1713,13 +1722,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -96,6 +96,7 @@ var g = &grammar{
 						pos:        position{line: 7, col: 10, offset: 149},
 						val:        "case01",
 						ignoreCase: false,
+						want:       "\"case01\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 7, col: 19, offset: 158},
@@ -143,6 +144,7 @@ var g = &grammar{
 						pos:        position{line: 8, col: 10, offset: 208},
 						val:        "case02",
 						ignoreCase: false,
+						want:       "\"case02\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 8, col: 19, offset: 217},
@@ -171,6 +173,7 @@ var g = &grammar{
 						pos:        position{line: 9, col: 10, offset: 239},
 						val:        "case03",
 						ignoreCase: false,
+						want:       "\"case03\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 9, col: 19, offset: 248},
@@ -182,6 +185,7 @@ var g = &grammar{
 							pos:        position{line: 9, col: 22, offset: 251},
 							val:        "x",
 							ignoreCase: false,
+							want:       "\"x\"",
 						},
 					},
 					&charClassMatcher{
@@ -204,6 +208,7 @@ var g = &grammar{
 						pos:        position{line: 10, col: 10, offset: 273},
 						val:        "case04",
 						ignoreCase: false,
+						want:       "\"case04\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 10, col: 19, offset: 282},
@@ -250,6 +255,7 @@ var g = &grammar{
 						pos:        position{line: 11, col: 10, offset: 334},
 						val:        "case05",
 						ignoreCase: false,
+						want:       "\"case05\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 11, col: 19, offset: 343},
@@ -261,12 +267,14 @@ var g = &grammar{
 							pos:        position{line: 11, col: 23, offset: 347},
 							val:        "not",
 							ignoreCase: false,
+							want:       "\"not\"",
 						},
 					},
 					&litMatcher{
 						pos:        position{line: 11, col: 29, offset: 353},
 						val:        "yes",
 						ignoreCase: false,
+						want:       "\"yes\"",
 					},
 				},
 			},
@@ -281,6 +289,7 @@ var g = &grammar{
 						pos:        position{line: 12, col: 10, offset: 370},
 						val:        "case06",
 						ignoreCase: false,
+						want:       "\"case06\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 12, col: 19, offset: 379},
@@ -300,6 +309,7 @@ var g = &grammar{
 						pos:        position{line: 12, col: 29, offset: 389},
 						val:        "x",
 						ignoreCase: false,
+						want:       "\"x\"",
 					},
 				},
 			},
@@ -314,6 +324,7 @@ var g = &grammar{
 						pos:        position{line: 13, col: 10, offset: 404},
 						val:        "case07",
 						ignoreCase: false,
+						want:       "\"case07\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 13, col: 19, offset: 413},
@@ -328,6 +339,7 @@ var g = &grammar{
 									pos:        position{line: 13, col: 24, offset: 418},
 									val:        "abc",
 									ignoreCase: true,
+									want:       "\"abc\"i",
 								},
 								&charClassMatcher{
 									pos:        position{line: 13, col: 33, offset: 427},
@@ -366,6 +378,7 @@ var g = &grammar{
 						pos:        position{line: 14, col: 10, offset: 460},
 						val:        "case08",
 						ignoreCase: false,
+						want:       "\"case08\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 14, col: 19, offset: 469},
@@ -377,6 +390,7 @@ var g = &grammar{
 							pos:        position{line: 14, col: 23, offset: 473},
 							val:        "a",
 							ignoreCase: true,
+							want:       "\"a\"i",
 						},
 					},
 					&anyMatcher{
@@ -395,6 +409,7 @@ var g = &grammar{
 						pos:        position{line: 15, col: 10, offset: 491},
 						val:        "case09",
 						ignoreCase: false,
+						want:       "\"case09\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 15, col: 19, offset: 500},
@@ -426,6 +441,7 @@ var g = &grammar{
 						pos:        position{line: 16, col: 10, offset: 523},
 						val:        "case10",
 						ignoreCase: false,
+						want:       "\"case10\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 16, col: 19, offset: 532},
@@ -440,6 +456,7 @@ var g = &grammar{
 									pos:        position{line: 16, col: 24, offset: 537},
 									val:        "0",
 									ignoreCase: false,
+									want:       "\"0\"",
 								},
 								&charClassMatcher{
 									pos:        position{line: 16, col: 30, offset: 543},
@@ -481,6 +498,7 @@ var g = &grammar{
 						pos:        position{line: 17, col: 10, offset: 579},
 						val:        "case11",
 						ignoreCase: false,
+						want:       "\"case11\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 17, col: 19, offset: 588},
@@ -494,6 +512,7 @@ var g = &grammar{
 								pos:        position{line: 17, col: 26, offset: 595},
 								val:        "a",
 								ignoreCase: false,
+								want:       "\"a\"",
 							},
 						},
 					},
@@ -501,6 +520,7 @@ var g = &grammar{
 						pos:        position{line: 17, col: 32, offset: 601},
 						val:        "a",
 						ignoreCase: false,
+						want:       "\"a\"",
 					},
 				},
 			},
@@ -512,6 +532,7 @@ var g = &grammar{
 				pos:        position{line: 19, col: 13, offset: 620},
 				val:        "inc",
 				ignoreCase: false,
+				want:       "\"inc\"",
 			},
 		},
 		{
@@ -521,6 +542,7 @@ var g = &grammar{
 				pos:        position{line: 20, col: 13, offset: 640},
 				val:        "dec",
 				ignoreCase: false,
+				want:       "\"dec\"",
 			},
 		},
 		{
@@ -530,6 +552,7 @@ var g = &grammar{
 				pos:        position{line: 21, col: 8, offset: 655},
 				val:        "zero",
 				ignoreCase: false,
+				want:       "\"zero\"",
 			},
 		},
 		{
@@ -539,6 +562,7 @@ var g = &grammar{
 				pos:        position{line: 22, col: 13, offset: 676},
 				val:        "oneOrMore",
 				ignoreCase: false,
+				want:       "\"oneOrMore\"",
 			},
 		},
 		{
@@ -900,20 +924,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1722,13 +1733,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -71,6 +71,7 @@ var g = &grammar{
 						pos:        position{line: 7, col: 13, offset: 212},
 						val:        "i",
 						ignoreCase: false,
+						want:       "\"i\"",
 					},
 					&andCodeExpr{
 						pos: position{line: 7, col: 17, offset: 216},
@@ -89,6 +90,7 @@ var g = &grammar{
 						pos:        position{line: 8, col: 13, offset: 313},
 						val:        "d",
 						ignoreCase: false,
+						want:       "\"d\"",
 					},
 					&andCodeExpr{
 						pos: position{line: 8, col: 17, offset: 317},
@@ -107,6 +109,7 @@ var g = &grammar{
 						pos:        position{line: 9, col: 8, offset: 409},
 						val:        "z",
 						ignoreCase: false,
+						want:       "\"z\"",
 					},
 					&andCodeExpr{
 						pos: position{line: 9, col: 12, offset: 413},
@@ -503,20 +506,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1325,13 +1315,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -503,6 +503,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1304,11 +1318,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1316,13 +1325,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -174,6 +174,7 @@ var g = &grammar{
 							pos:        position{line: 40, col: 27, offset: 978},
 							val:        ":",
 							ignoreCase: false,
+							want:       "\":\"",
 						},
 					},
 				},
@@ -219,6 +220,7 @@ var g = &grammar{
 					pos:        position{line: 50, col: 8, offset: 1120},
 					val:        "noop",
 					ignoreCase: false,
+					want:       "\"noop\"",
 				},
 			},
 		},
@@ -235,6 +237,7 @@ var g = &grammar{
 							pos:        position{line: 54, col: 8, offset: 1162},
 							val:        "jump",
 							ignoreCase: false,
+							want:       "\"jump\"",
 						},
 						&ruleRefExpr{
 							pos:  position{line: 54, col: 15, offset: 1169},
@@ -720,20 +723,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1542,13 +1532,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -720,6 +720,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1521,11 +1535,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1533,13 +1542,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/goto_state/goto_state.go
+++ b/test/goto_state/goto_state.go
@@ -748,6 +748,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1549,11 +1563,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1561,13 +1570,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/goto_state/goto_state.go
+++ b/test/goto_state/goto_state.go
@@ -179,6 +179,7 @@ var g = &grammar{
 						pos:        position{line: 40, col: 71, offset: 1168},
 						val:        ":",
 						ignoreCase: false,
+						want:       "\":\"",
 					},
 				},
 			},
@@ -223,6 +224,7 @@ var g = &grammar{
 					pos:        position{line: 46, col: 8, offset: 1251},
 					val:        "noop",
 					ignoreCase: false,
+					want:       "\"noop\"",
 				},
 			},
 		},
@@ -239,6 +241,7 @@ var g = &grammar{
 							pos:        position{line: 50, col: 8, offset: 1293},
 							val:        "jump",
 							ignoreCase: false,
+							want:       "\"jump\"",
 						},
 						&ruleRefExpr{
 							pos:  position{line: 50, col: 15, offset: 1300},
@@ -748,20 +751,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1570,13 +1560,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -45,6 +45,7 @@ var g = &grammar{
 											pos:        position{line: 5, col: 26, offset: 45},
 											val:        ".",
 											ignoreCase: false,
+											want:       "\".\"",
 										},
 									},
 								},
@@ -424,20 +425,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1246,13 +1234,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -424,6 +424,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1225,11 +1239,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1237,13 +1246,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -442,6 +442,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1243,11 +1257,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1255,13 +1264,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -442,20 +442,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1264,13 +1251,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_65/issue_65.go
+++ b/test/issue_65/issue_65.go
@@ -438,6 +438,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1239,11 +1253,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1251,13 +1260,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_65/issue_65.go
+++ b/test/issue_65/issue_65.go
@@ -58,6 +58,7 @@ var g = &grammar{
 									pos:        position{line: 6, col: 13, offset: 52},
 									val:        ",",
 									ignoreCase: false,
+									want:       "\",\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 6, col: 17, offset: 56},
@@ -79,6 +80,7 @@ var g = &grammar{
 						pos:        position{line: 7, col: 6, offset: 66},
 						val:        "X",
 						ignoreCase: false,
+						want:       "\"X\"",
 					},
 					&zeroOrOneExpr{
 						pos: position{line: 7, col: 10, offset: 70},
@@ -100,6 +102,7 @@ var g = &grammar{
 					pos:        position{line: 8, col: 6, offset: 78},
 					val:        "Y",
 					ignoreCase: false,
+					want:       "\"Y\"",
 				},
 			},
 		},
@@ -438,20 +441,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1260,13 +1250,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_65/optimized-grammar/issue_65.go
+++ b/test/issue_65/optimized-grammar/issue_65.go
@@ -423,6 +423,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1224,11 +1238,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1236,13 +1245,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_65/optimized-grammar/issue_65.go
+++ b/test/issue_65/optimized-grammar/issue_65.go
@@ -30,6 +30,7 @@ var g = &grammar{
 						pos:        position{line: 7, col: 6, offset: 66},
 						val:        "X",
 						ignoreCase: false,
+						want:       "\"X\"",
 					},
 					&zeroOrOneExpr{
 						pos: position{line: 7, col: 10, offset: 70},
@@ -40,6 +41,7 @@ var g = &grammar{
 								pos:        position{line: 8, col: 6, offset: 78},
 								val:        "Y",
 								ignoreCase: false,
+								want:       "\"Y\"",
 							},
 						},
 					},
@@ -52,6 +54,7 @@ var g = &grammar{
 									pos:        position{line: 6, col: 13, offset: 52},
 									val:        ",X",
 									ignoreCase: false,
+									want:       "\",X\"",
 								},
 								&zeroOrOneExpr{
 									pos: position{line: 7, col: 10, offset: 70},
@@ -62,6 +65,7 @@ var g = &grammar{
 											pos:        position{line: 8, col: 6, offset: 78},
 											val:        "Y",
 											ignoreCase: false,
+											want:       "\"Y\"",
 										},
 									},
 								},
@@ -423,20 +427,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1245,13 +1236,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_65/optimized/issue_65.go
+++ b/test/issue_65/optimized/issue_65.go
@@ -359,6 +359,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -968,11 +982,6 @@ func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -980,13 +989,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_65/optimized/issue_65.go
+++ b/test/issue_65/optimized/issue_65.go
@@ -57,6 +57,7 @@ var g = &grammar{
 									pos:        position{line: 6, col: 13, offset: 52},
 									val:        ",",
 									ignoreCase: false,
+									want:       "\",\"",
 								},
 								&ruleRefExpr{
 									pos:  position{line: 6, col: 17, offset: 56},
@@ -78,6 +79,7 @@ var g = &grammar{
 						pos:        position{line: 7, col: 6, offset: 66},
 						val:        "X",
 						ignoreCase: false,
+						want:       "\"X\"",
 					},
 					&zeroOrOneExpr{
 						pos: position{line: 7, col: 10, offset: 70},
@@ -99,6 +101,7 @@ var g = &grammar{
 					pos:        position{line: 8, col: 6, offset: 78},
 					val:        "Y",
 					ignoreCase: false,
+					want:       "\"Y\"",
 				},
 			},
 		},
@@ -359,20 +362,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -989,13 +979,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_70/issue_70.go
+++ b/test/issue_70/issue_70.go
@@ -67,6 +67,7 @@ var g = &grammar{
 						pos:        position{line: 7, col: 6, offset: 67},
 						val:        "Z",
 						ignoreCase: false,
+						want:       "\"Z\"",
 					},
 				},
 			},
@@ -415,20 +416,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1237,13 +1225,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_70/issue_70.go
+++ b/test/issue_70/issue_70.go
@@ -415,6 +415,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1216,11 +1230,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1228,13 +1237,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_70/optimized-grammar/issue_70.go
+++ b/test/issue_70/optimized-grammar/issue_70.go
@@ -41,6 +41,7 @@ var g = &grammar{
 										pos:        position{line: 7, col: 6, offset: 67},
 										val:        "Z",
 										ignoreCase: false,
+										want:       "\"Z\"",
 									},
 								},
 							},
@@ -399,20 +400,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1221,13 +1209,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_70/optimized-grammar/issue_70.go
+++ b/test/issue_70/optimized-grammar/issue_70.go
@@ -399,6 +399,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1200,11 +1214,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1212,13 +1221,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_70/optimized/issue_70.go
+++ b/test/issue_70/optimized/issue_70.go
@@ -66,6 +66,7 @@ var g = &grammar{
 						pos:        position{line: 7, col: 6, offset: 67},
 						val:        "Z",
 						ignoreCase: false,
+						want:       "\"Z\"",
 					},
 				},
 			},
@@ -336,20 +337,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -966,13 +954,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_70/optimized/issue_70.go
+++ b/test/issue_70/optimized/issue_70.go
@@ -336,6 +336,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -945,11 +959,6 @@ func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -957,13 +966,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_70b/issue_70b.go
+++ b/test/issue_70b/issue_70b.go
@@ -401,6 +401,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1202,11 +1216,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1214,13 +1223,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_70b/issue_70b.go
+++ b/test/issue_70b/issue_70b.go
@@ -401,20 +401,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1223,13 +1210,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_80/issue_80.go
+++ b/test/issue_80/issue_80.go
@@ -435,6 +435,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1236,11 +1250,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1248,13 +1257,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/issue_80/issue_80.go
+++ b/test/issue_80/issue_80.go
@@ -435,20 +435,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1257,13 +1244,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -662,6 +662,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1463,11 +1477,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1475,13 +1484,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -179,6 +179,7 @@ var g = &grammar{
 								pos:        position{line: 27, col: 12, offset: 527},
 								val:        ",",
 								ignoreCase: false,
+								want:       "\",\"",
 							},
 						},
 					},
@@ -264,6 +265,7 @@ var g = &grammar{
 											pos:        position{line: 35, col: 11, offset: 721},
 											val:        ",",
 											ignoreCase: false,
+											want:       "\",\"",
 										},
 									},
 									&anyMatcher{
@@ -662,20 +664,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1484,13 +1473,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -517,20 +517,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1339,13 +1326,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -517,6 +517,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1318,11 +1332,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1330,13 +1339,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -352,6 +352,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1153,11 +1167,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1165,13 +1174,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -352,20 +352,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1174,13 +1161,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -36,6 +36,7 @@ var g = &grammar{
 									pos:        position{line: 5, col: 7, offset: 32},
 									val:        "a",
 									ignoreCase: false,
+									want:       "\"a\"",
 								},
 							},
 							&notCodeExpr{
@@ -54,6 +55,7 @@ var g = &grammar{
 									pos:        position{line: 10, col: 5, offset: 100},
 									val:        "b",
 									ignoreCase: false,
+									want:       "\"b\"",
 								},
 							},
 							&notCodeExpr{
@@ -72,6 +74,7 @@ var g = &grammar{
 									pos:        position{line: 15, col: 5, offset: 167},
 									val:        "d",
 									ignoreCase: false,
+									want:       "\"d\"",
 								},
 							},
 							&andCodeExpr{
@@ -568,20 +571,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1390,13 +1380,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -568,6 +568,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1369,11 +1383,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1381,13 +1390,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -41,6 +41,7 @@ var g = &grammar{
 							pos:        position{line: 13, col: 12, offset: 224},
 							val:        "\n",
 							ignoreCase: false,
+							want:       "\"\\n\"",
 						},
 						&labeledExpr{
 							pos:   position{line: 13, col: 17, offset: 229},
@@ -60,6 +61,7 @@ var g = &grammar{
 							pos:        position{line: 13, col: 26, offset: 238},
 							val:        "\n",
 							ignoreCase: false,
+							want:       "\"\\n\"",
 						},
 						&labeledExpr{
 							pos:   position{line: 13, col: 31, offset: 243},
@@ -414,20 +416,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1236,13 +1225,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -414,6 +414,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1215,11 +1229,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1227,13 +1236,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -48,6 +48,7 @@ var g = &grammar{
 														pos:        position{line: 14, col: 5, offset: 173},
 														val:        "abc",
 														ignoreCase: false,
+														want:       "\"abc\"",
 													},
 													&stateCodeExpr{
 														pos: position{line: 18, col: 9, offset: 285},
@@ -57,6 +58,7 @@ var g = &grammar{
 														pos:        position{line: 14, col: 12, offset: 180},
 														val:        "d",
 														ignoreCase: false,
+														want:       "\"d\"",
 													},
 												},
 											},
@@ -67,6 +69,7 @@ var g = &grammar{
 														pos:        position{line: 15, col: 5, offset: 188},
 														val:        "abc",
 														ignoreCase: false,
+														want:       "\"abc\"",
 													},
 													&stateCodeExpr{
 														pos: position{line: 19, col: 11, offset: 362},
@@ -76,6 +79,7 @@ var g = &grammar{
 														pos:        position{line: 15, col: 12, offset: 195},
 														val:        "e",
 														ignoreCase: false,
+														want:       "\"e\"",
 													},
 												},
 											},
@@ -86,6 +90,7 @@ var g = &grammar{
 														pos:        position{line: 16, col: 5, offset: 203},
 														val:        "abcf",
 														ignoreCase: false,
+														want:       "\"abcf\"",
 													},
 													&stateCodeExpr{
 														pos: position{line: 16, col: 12, offset: 210},
@@ -494,20 +499,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1316,13 +1308,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -494,6 +494,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1295,11 +1309,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1307,13 +1316,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/stateclone/stateclone.go
+++ b/test/stateclone/stateclone.go
@@ -87,6 +87,7 @@ var g = &grammar{
 						pos:        position{line: 25, col: 5, offset: 359},
 						val:        "ab",
 						ignoreCase: false,
+						want:       "\"ab\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 25, col: 10, offset: 364},
@@ -96,6 +97,7 @@ var g = &grammar{
 						pos:        position{line: 25, col: 12, offset: 366},
 						val:        "d",
 						ignoreCase: false,
+						want:       "\"d\"",
 					},
 				},
 			},
@@ -110,6 +112,7 @@ var g = &grammar{
 						pos:        position{line: 26, col: 5, offset: 374},
 						val:        "a",
 						ignoreCase: false,
+						want:       "\"a\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 26, col: 9, offset: 378},
@@ -119,6 +122,7 @@ var g = &grammar{
 						pos:        position{line: 26, col: 12, offset: 381},
 						val:        "e",
 						ignoreCase: false,
+						want:       "\"e\"",
 					},
 				},
 			},
@@ -133,6 +137,7 @@ var g = &grammar{
 						pos:        position{line: 27, col: 5, offset: 389},
 						val:        "abcf",
 						ignoreCase: false,
+						want:       "\"abcf\"",
 					},
 					&stateCodeExpr{
 						pos: position{line: 27, col: 12, offset: 396},
@@ -151,6 +156,7 @@ var g = &grammar{
 						pos:        position{line: 29, col: 5, offset: 471},
 						val:        "c",
 						ignoreCase: false,
+						want:       "\"c\"",
 					},
 					&stateCodeExpr{
 						pos: position{line: 29, col: 9, offset: 475},
@@ -169,6 +175,7 @@ var g = &grammar{
 						pos:        position{line: 30, col: 6, offset: 551},
 						val:        "bc",
 						ignoreCase: false,
+						want:       "\"bc\"",
 					},
 					&stateCodeExpr{
 						pos: position{line: 30, col: 11, offset: 556},
@@ -187,11 +194,13 @@ var g = &grammar{
 						pos:        position{line: 32, col: 6, offset: 632},
 						val:        " ",
 						ignoreCase: false,
+						want:       "\" \"",
 					},
 					&litMatcher{
 						pos:        position{line: 32, col: 12, offset: 638},
 						val:        "\n",
 						ignoreCase: false,
+						want:       "\"\\n\"",
 					},
 				},
 			},
@@ -580,20 +589,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1402,13 +1398,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/stateclone/stateclone.go
+++ b/test/stateclone/stateclone.go
@@ -580,6 +580,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1381,11 +1395,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1393,13 +1402,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/statereadonly/statereadonly.go
+++ b/test/statereadonly/statereadonly.go
@@ -561,6 +561,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1362,11 +1376,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1374,13 +1383,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/statereadonly/statereadonly.go
+++ b/test/statereadonly/statereadonly.go
@@ -79,6 +79,7 @@ var g = &grammar{
 						pos:        position{line: 7, col: 5, offset: 130},
 						val:        "ab",
 						ignoreCase: false,
+						want:       "\"ab\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 7, col: 10, offset: 135},
@@ -88,6 +89,7 @@ var g = &grammar{
 						pos:        position{line: 7, col: 12, offset: 137},
 						val:        "d",
 						ignoreCase: false,
+						want:       "\"d\"",
 					},
 				},
 			},
@@ -102,6 +104,7 @@ var g = &grammar{
 						pos:        position{line: 8, col: 5, offset: 145},
 						val:        "a",
 						ignoreCase: false,
+						want:       "\"a\"",
 					},
 					&ruleRefExpr{
 						pos:  position{line: 8, col: 9, offset: 149},
@@ -111,6 +114,7 @@ var g = &grammar{
 						pos:        position{line: 8, col: 12, offset: 152},
 						val:        "e",
 						ignoreCase: false,
+						want:       "\"e\"",
 					},
 				},
 			},
@@ -125,6 +129,7 @@ var g = &grammar{
 					pos:        position{line: 9, col: 5, offset: 160},
 					val:        "abcf",
 					ignoreCase: false,
+					want:       "\"abcf\"",
 				},
 			},
 		},
@@ -138,6 +143,7 @@ var g = &grammar{
 						pos:        position{line: 11, col: 5, offset: 242},
 						val:        "c",
 						ignoreCase: false,
+						want:       "\"c\"",
 					},
 					&andCodeExpr{
 						pos: position{line: 11, col: 9, offset: 246},
@@ -156,6 +162,7 @@ var g = &grammar{
 						pos:        position{line: 12, col: 6, offset: 324},
 						val:        "bc",
 						ignoreCase: false,
+						want:       "\"bc\"",
 					},
 					&notCodeExpr{
 						pos: position{line: 12, col: 11, offset: 329},
@@ -174,11 +181,13 @@ var g = &grammar{
 						pos:        position{line: 14, col: 6, offset: 408},
 						val:        " ",
 						ignoreCase: false,
+						want:       "\" \"",
 					},
 					&litMatcher{
 						pos:        position{line: 14, col: 12, offset: 414},
 						val:        "\n",
 						ignoreCase: false,
+						want:       "\"\\n\"",
 					},
 				},
 			},
@@ -561,20 +570,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1383,13 +1379,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/staterestore/optimized/staterestore.go
+++ b/test/staterestore/optimized/staterestore.go
@@ -52,6 +52,7 @@ var g = &grammar{
 							pos:        position{line: 35, col: 9, offset: 605},
 							val:        "f",
 							ignoreCase: false,
+							want:       "\"f\"",
 						},
 						&zeroOrOneExpr{
 							pos: position{line: 35, col: 13, offset: 609},
@@ -70,6 +71,7 @@ var g = &grammar{
 															pos:        position{line: 36, col: 8, offset: 628},
 															val:        "\n",
 															ignoreCase: false,
+															want:       "\"\\n\"",
 														},
 														&stateCodeExpr{
 															pos: position{line: 37, col: 3, offset: 635},
@@ -84,6 +86,7 @@ var g = &grammar{
 															pos:        position{line: 44, col: 12, offset: 736},
 															val:        "#",
 															ignoreCase: false,
+															want:       "\"#\"",
 														},
 														&zeroOrMoreExpr{
 															pos: position{line: 44, col: 16, offset: 740},
@@ -99,6 +102,7 @@ var g = &grammar{
 																					pos:        position{line: 36, col: 8, offset: 628},
 																					val:        "\n",
 																					ignoreCase: false,
+																					want:       "\"\\n\"",
 																				},
 																				&stateCodeExpr{
 																					pos: position{line: 37, col: 3, offset: 635},
@@ -122,6 +126,7 @@ var g = &grammar{
 										pos:        position{line: 34, col: 9, offset: 593},
 										val:        "Z",
 										ignoreCase: false,
+										want:       "\"Z\"",
 									},
 								},
 							},
@@ -143,6 +148,7 @@ var g = &grammar{
 															pos:        position{line: 36, col: 8, offset: 628},
 															val:        "\n",
 															ignoreCase: false,
+															want:       "\"\\n\"",
 														},
 														&stateCodeExpr{
 															pos: position{line: 37, col: 3, offset: 635},
@@ -157,6 +163,7 @@ var g = &grammar{
 															pos:        position{line: 44, col: 12, offset: 736},
 															val:        "#",
 															ignoreCase: false,
+															want:       "\"#\"",
 														},
 														&zeroOrMoreExpr{
 															pos: position{line: 44, col: 16, offset: 740},
@@ -172,6 +179,7 @@ var g = &grammar{
 																					pos:        position{line: 36, col: 8, offset: 628},
 																					val:        "\n",
 																					ignoreCase: false,
+																					want:       "\"\\n\"",
 																				},
 																				&stateCodeExpr{
 																					pos: position{line: 37, col: 3, offset: 635},
@@ -195,6 +203,7 @@ var g = &grammar{
 										pos:        position{line: 34, col: 9, offset: 593},
 										val:        "Z",
 										ignoreCase: false,
+										want:       "\"Z\"",
 									},
 								},
 							},
@@ -216,6 +225,7 @@ var g = &grammar{
 															pos:        position{line: 36, col: 8, offset: 628},
 															val:        "\n",
 															ignoreCase: false,
+															want:       "\"\\n\"",
 														},
 														&stateCodeExpr{
 															pos: position{line: 37, col: 3, offset: 635},
@@ -230,6 +240,7 @@ var g = &grammar{
 															pos:        position{line: 44, col: 12, offset: 736},
 															val:        "#",
 															ignoreCase: false,
+															want:       "\"#\"",
 														},
 														&zeroOrMoreExpr{
 															pos: position{line: 44, col: 16, offset: 740},
@@ -245,6 +256,7 @@ var g = &grammar{
 																					pos:        position{line: 36, col: 8, offset: 628},
 																					val:        "\n",
 																					ignoreCase: false,
+																					want:       "\"\\n\"",
 																				},
 																				&stateCodeExpr{
 																					pos: position{line: 37, col: 3, offset: 635},
@@ -268,6 +280,7 @@ var g = &grammar{
 										pos:        position{line: 34, col: 9, offset: 593},
 										val:        "Z",
 										ignoreCase: false,
+										want:       "\"Z\"",
 									},
 								},
 							},
@@ -284,6 +297,7 @@ var g = &grammar{
 												pos:        position{line: 36, col: 8, offset: 628},
 												val:        "\n",
 												ignoreCase: false,
+												want:       "\"\\n\"",
 											},
 											&stateCodeExpr{
 												pos: position{line: 37, col: 3, offset: 635},
@@ -298,6 +312,7 @@ var g = &grammar{
 												pos:        position{line: 44, col: 12, offset: 736},
 												val:        "#",
 												ignoreCase: false,
+												want:       "\"#\"",
 											},
 											&zeroOrMoreExpr{
 												pos: position{line: 44, col: 16, offset: 740},
@@ -313,6 +328,7 @@ var g = &grammar{
 																		pos:        position{line: 36, col: 8, offset: 628},
 																		val:        "\n",
 																		ignoreCase: false,
+																		want:       "\"\\n\"",
 																	},
 																	&stateCodeExpr{
 																		pos: position{line: 37, col: 3, offset: 635},
@@ -364,6 +380,7 @@ var g = &grammar{
 										pos:        position{line: 36, col: 8, offset: 628},
 										val:        "\n",
 										ignoreCase: false,
+										want:       "\"\\n\"",
 									},
 									&stateCodeExpr{
 										pos: position{line: 37, col: 3, offset: 635},
@@ -410,6 +427,7 @@ var g = &grammar{
 												pos:        position{line: 36, col: 8, offset: 628},
 												val:        "\n",
 												ignoreCase: false,
+												want:       "\"\\n\"",
 											},
 											&stateCodeExpr{
 												pos: position{line: 37, col: 3, offset: 635},
@@ -425,6 +443,7 @@ var g = &grammar{
 											pos:        position{line: 36, col: 8, offset: 628},
 											val:        "\n",
 											ignoreCase: false,
+											want:       "\"\\n\"",
 										},
 										&stateCodeExpr{
 											pos: position{line: 37, col: 3, offset: 635},
@@ -925,20 +944,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1600,13 +1606,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/staterestore/optimized/staterestore.go
+++ b/test/staterestore/optimized/staterestore.go
@@ -925,6 +925,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1579,11 +1593,6 @@ func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1591,13 +1600,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/staterestore/standard/staterestore.go
+++ b/test/staterestore/standard/staterestore.go
@@ -142,6 +142,7 @@ var g = &grammar{
 						pos:        position{line: 34, col: 9, offset: 593},
 						val:        "Z",
 						ignoreCase: false,
+						want:       "\"Z\"",
 					},
 				},
 			},
@@ -156,6 +157,7 @@ var g = &grammar{
 						pos:        position{line: 35, col: 9, offset: 605},
 						val:        "f",
 						ignoreCase: false,
+						want:       "\"f\"",
 					},
 					&zeroOrOneExpr{
 						pos: position{line: 35, col: 13, offset: 609},
@@ -191,6 +193,7 @@ var g = &grammar{
 						pos:        position{line: 36, col: 8, offset: 628},
 						val:        "\n",
 						ignoreCase: false,
+						want:       "\"\\n\"",
 					},
 					&stateCodeExpr{
 						pos: position{line: 37, col: 3, offset: 635},
@@ -209,6 +212,7 @@ var g = &grammar{
 						pos:        position{line: 44, col: 12, offset: 736},
 						val:        "#",
 						ignoreCase: false,
+						want:       "\"#\"",
 					},
 					&zeroOrMoreExpr{
 						pos: position{line: 44, col: 16, offset: 740},
@@ -665,20 +669,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1487,13 +1478,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/staterestore/standard/staterestore.go
+++ b/test/staterestore/standard/staterestore.go
@@ -665,6 +665,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1466,11 +1480,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1478,13 +1487,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/staterestore/staterestore.go
+++ b/test/staterestore/staterestore.go
@@ -142,6 +142,7 @@ var g = &grammar{
 						pos:        position{line: 34, col: 9, offset: 593},
 						val:        "Z",
 						ignoreCase: false,
+						want:       "\"Z\"",
 					},
 				},
 			},
@@ -156,6 +157,7 @@ var g = &grammar{
 						pos:        position{line: 35, col: 9, offset: 605},
 						val:        "f",
 						ignoreCase: false,
+						want:       "\"f\"",
 					},
 					&zeroOrOneExpr{
 						pos: position{line: 35, col: 13, offset: 609},
@@ -191,6 +193,7 @@ var g = &grammar{
 						pos:        position{line: 36, col: 8, offset: 628},
 						val:        "\n",
 						ignoreCase: false,
+						want:       "\"\\n\"",
 					},
 					&stateCodeExpr{
 						pos: position{line: 37, col: 3, offset: 635},
@@ -209,6 +212,7 @@ var g = &grammar{
 						pos:        position{line: 44, col: 12, offset: 736},
 						val:        "#",
 						ignoreCase: false,
+						want:       "\"#\"",
 					},
 					&zeroOrMoreExpr{
 						pos: position{line: 44, col: 16, offset: 740},
@@ -665,20 +669,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -1487,13 +1478,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 

--- a/test/staterestore/staterestore.go
+++ b/test/staterestore/staterestore.go
@@ -665,6 +665,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -1466,11 +1480,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -1478,13 +1487,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -1447,6 +1447,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 // nolint: structcheck
@@ -2248,11 +2262,6 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 		defer p.out(p.in("parseLitMatcher"))
 	}
 
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -2260,13 +2269,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -58,6 +58,7 @@ var g = &grammar{
 							pos:        position{line: 11, col: 10, offset: 117},
 							val:        "case01:",
 							ignoreCase: false,
+							want:       "\"case01:\"",
 						},
 						&labeledExpr{
 							pos:   position{line: 11, col: 20, offset: 127},
@@ -229,6 +230,7 @@ var g = &grammar{
 						pos:        position{line: 31, col: 10, offset: 646},
 						val:        "case02:",
 						ignoreCase: false,
+						want:       "\"case02:\"",
 					},
 					&choiceExpr{
 						pos: position{line: 31, col: 21, offset: 657},
@@ -267,6 +269,7 @@ var g = &grammar{
 							pos:        position{line: 38, col: 10, offset: 805},
 							val:        "case03:",
 							ignoreCase: false,
+							want:       "\"case03:\"",
 						},
 						&labeledExpr{
 							pos:   position{line: 38, col: 20, offset: 815},
@@ -572,6 +575,7 @@ var g = &grammar{
 							pos:        position{line: 68, col: 10, offset: 1820},
 							val:        "case04:",
 							ignoreCase: false,
+							want:       "\"case04:\"",
 						},
 						&labeledExpr{
 							pos:   position{line: 68, col: 20, offset: 1830},
@@ -1447,20 +1451,7 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
-	wantCache  string
-}
-
-func (lit *litMatcher) want() string {
-	if lit.wantCache != "" {
-		return lit.wantCache
-	}
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
-	lit.wantCache = val
-	return val
+	want       string
 }
 
 // nolint: structcheck
@@ -2269,13 +2260,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, lit.want())
+			p.failAt(false, start.position, lit.want)
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, lit.want())
+	p.failAt(true, start.position, lit.want)
 	return p.sliceFrom(start), true
 }
 


### PR DESCRIPTION
parseLitMatcher() was calling strconv.AppendQuote() each time, which my
profiler discovered was costing a measurably large amount of runtime
during parsing within dhall-golang.

This commit adds a cache field to the litMatcher struct so that we only
have to compute the `want` value once per litMatcher instead of once
each time we parse with the litMatcher.

Resolves #94.