### PR TITLE
Fix typos

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -304,7 +304,7 @@ func (a *ActionExpr) InitialNames() map[string]struct{} {
 	return names
 }
 
-// ThrowExpr is an expression that throws an FailureLabel to be catched by a
+// ThrowExpr is an expression that throws an FailureLabel to be caught by a
 // RecoveryChoiceExpr.
 type ThrowExpr struct {
 	p     Pos

--- a/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
+++ b/bootstrap/cmd/bootstrap-pigeon/bootstrap_pigeon.go
@@ -2255,7 +2255,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/builder/generated_static_code.go
+++ b/builder/generated_static_code.go
@@ -17,7 +17,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -1035,8 +1035,8 @@ func (p *parser) parseExprWrap(expr any) (any, bool) {
 	var pt savepoint
 
 	// ==template== {{ if .LeftRecursion }}
-	isLeftRecusion := p.rstack[len(p.rstack)-1].leftRecursive
-	if p.memoize && !isLeftRecusion {
+	isLeftRecursion := p.rstack[len(p.rstack)-1].leftRecursive
+	if p.memoize && !isLeftRecursion {
 	// {{ else }}
 	if p.memoize {
 	// {{ end }} ==template==
@@ -1053,7 +1053,7 @@ func (p *parser) parseExprWrap(expr any) (any, bool) {
 
 	// ==template== {{ if not .Optimize }}
 	// ==template== {{ if .LeftRecursion }}
-	if p.memoize && !isLeftRecusion {
+	if p.memoize && !isLeftRecursion {
 	// {{ else }}
 	if p.memoize {
 	// {{ end }} ==template==

--- a/builder/static_code.go
+++ b/builder/static_code.go
@@ -35,7 +35,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -1053,8 +1053,8 @@ func (p *parser) parseExprWrap(expr any) (any, bool) {
 	var pt savepoint
 
 	// ==template== {{ if .LeftRecursion }}
-	isLeftRecusion := p.rstack[len(p.rstack)-1].leftRecursive
-	if p.memoize && !isLeftRecusion {
+	isLeftRecursion := p.rstack[len(p.rstack)-1].leftRecursive
+	if p.memoize && !isLeftRecursion {
 	// {{ else }}
 	if p.memoize {
 	// {{ end }} ==template==
@@ -1071,7 +1071,7 @@ func (p *parser) parseExprWrap(expr any) (any, bool) {
 
 	// ==template== {{ if not .Optimize }}
 	// ==template== {{ if .LeftRecursion }}
-	if p.memoize && !isLeftRecusion {
+	if p.memoize && !isLeftRecursion {
 	// {{ else }}
 	if p.memoize {
 	// {{ end }} ==template==

--- a/doc.go
+++ b/doc.go
@@ -507,7 +507,7 @@ The original error can be accessed this way:
 		}
 	}
 
-By defaut the parser will continue after an error is returned and will
+By default the parser will continue after an error is returned and will
 cumulate all errors found during parsing. If the grammar reaches a point
 where it shouldn't continue, a panic statement can be used to terminate
 parsing. The panic will be caught at the top-level of the Parse* call

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -468,7 +468,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/examples/indentation/indentation.go
+++ b/examples/indentation/indentation.go
@@ -781,7 +781,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -763,7 +763,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/examples/json/optimized-grammar/json.go
+++ b/examples/json/optimized-grammar/json.go
@@ -940,7 +940,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/examples/json/optimized/json.go
+++ b/examples/json/optimized/json.go
@@ -769,7 +769,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/main.go
+++ b/main.go
@@ -199,7 +199,7 @@ the generated code is written to this file instead.
 	-optimize-basic-latin
 		generate optimized parser for Unicode Basic Latin character set
 	-optimize-grammar
-		performes several performance optimizations on the grammar (EXPERIMENTAL FEATURE)
+		perform several performance optimizations on the grammar (EXPERIMENTAL FEATURE)
 	-optimize-parser
 		generate optimized parser without Debug and Memoize options and
 		with some other optimizations applied.

--- a/pigeon.go
+++ b/pigeon.go
@@ -3347,7 +3347,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/alternate_entrypoint/altentry.go
+++ b/test/alternate_entrypoint/altentry.go
@@ -237,7 +237,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/andnot/andnot.go
+++ b/test/andnot/andnot.go
@@ -177,7 +177,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/emptystate/emptystate.go
+++ b/test/emptystate/emptystate.go
@@ -237,7 +237,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/errorpos/errorpos.go
+++ b/test/errorpos/errorpos.go
@@ -616,7 +616,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/global_store/global_store.go
+++ b/test/global_store/global_store.go
@@ -198,7 +198,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/goto/goto.go
+++ b/test/goto/goto.go
@@ -415,7 +415,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/goto_state/goto_state.go
+++ b/test/goto_state/goto_state.go
@@ -443,7 +443,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/issue_1/issue_1.go
+++ b/test/issue_1/issue_1.go
@@ -117,7 +117,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/issue_115/issue_115.go
+++ b/test/issue_115/issue_115.go
@@ -57,7 +57,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/issue_134/issue_134.go
+++ b/test/issue_134/issue_134.go
@@ -57,7 +57,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/issue_18/issue_18.go
+++ b/test/issue_18/issue_18.go
@@ -134,7 +134,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/issue_65/issue_65.go
+++ b/test/issue_65/issue_65.go
@@ -133,7 +133,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/issue_65/optimized-grammar/issue_65.go
+++ b/test/issue_65/optimized-grammar/issue_65.go
@@ -119,7 +119,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/issue_65/optimized/issue_65.go
+++ b/test/issue_65/optimized/issue_65.go
@@ -132,7 +132,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/issue_70/issue_70.go
+++ b/test/issue_70/issue_70.go
@@ -108,7 +108,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/issue_70/optimized-grammar/issue_70.go
+++ b/test/issue_70/optimized-grammar/issue_70.go
@@ -92,7 +92,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/issue_70/optimized/issue_70.go
+++ b/test/issue_70/optimized/issue_70.go
@@ -107,7 +107,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/issue_70b/issue_70b.go
+++ b/test/issue_70b/issue_70b.go
@@ -97,7 +97,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -1028,8 +1028,8 @@ func (p *parser) parseRule(rule *rule) (any, bool) {
 func (p *parser) parseExprWrap(expr any) (any, bool) {
 	var pt savepoint
 
-	isLeftRecusion := p.rstack[len(p.rstack)-1].leftRecursive
-	if p.memoize && !isLeftRecusion {
+	isLeftRecursion := p.rstack[len(p.rstack)-1].leftRecursive
+	if p.memoize && !isLeftRecursion {
 		res, ok := p.getMemoized(expr)
 		if ok {
 			p.restore(res.end)
@@ -1040,7 +1040,7 @@ func (p *parser) parseExprWrap(expr any) (any, bool) {
 
 	val, ok := p.parseExpr(expr)
 
-	if p.memoize && !isLeftRecusion {
+	if p.memoize && !isLeftRecursion {
 		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
 	}
 	return val, ok

--- a/test/issue_79/issue_79.go
+++ b/test/issue_79/issue_79.go
@@ -230,7 +230,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -1142,8 +1142,8 @@ func (p *parser) parseRule(rule *rule) (any, bool) {
 func (p *parser) parseExprWrap(expr any) (any, bool) {
 	var pt savepoint
 
-	isLeftRecusion := p.rstack[len(p.rstack)-1].leftRecursive
-	if p.memoize && !isLeftRecusion {
+	isLeftRecursion := p.rstack[len(p.rstack)-1].leftRecursive
+	if p.memoize && !isLeftRecursion {
 		res, ok := p.getMemoized(expr)
 		if ok {
 			p.restore(res.end)
@@ -1154,7 +1154,7 @@ func (p *parser) parseExprWrap(expr any) (any, bool) {
 
 	val, ok := p.parseExpr(expr)
 
-	if p.memoize && !isLeftRecusion {
+	if p.memoize && !isLeftRecursion {
 		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
 	}
 	return val, ok

--- a/test/issue_80/issue_80.go
+++ b/test/issue_80/issue_80.go
@@ -127,7 +127,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/labeled_failures/labeled_failures.go
+++ b/test/labeled_failures/labeled_failures.go
@@ -356,7 +356,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/left_recursion/optimized/leftrecursion/left_recursion.go
+++ b/test/left_recursion/optimized/leftrecursion/left_recursion.go
@@ -362,7 +362,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/left_recursion/optimized/withoutleftrecursion/without_left_recursion.go
+++ b/test/left_recursion/optimized/withoutleftrecursion/without_left_recursion.go
@@ -318,7 +318,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/left_recursion/standart/leftrecursion/left_recursion.go
+++ b/test/left_recursion/standart/leftrecursion/left_recursion.go
@@ -363,7 +363,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -1294,8 +1294,8 @@ func (p *parser) parseRule(rule *rule) (any, bool) {
 func (p *parser) parseExprWrap(expr any) (any, bool) {
 	var pt savepoint
 
-	isLeftRecusion := p.rstack[len(p.rstack)-1].leftRecursive
-	if p.memoize && !isLeftRecusion {
+	isLeftRecursion := p.rstack[len(p.rstack)-1].leftRecursive
+	if p.memoize && !isLeftRecursion {
 		res, ok := p.getMemoized(expr)
 		if ok {
 			p.restore(res.end)
@@ -1306,7 +1306,7 @@ func (p *parser) parseExprWrap(expr any) (any, bool) {
 
 	val, ok := p.parseExpr(expr)
 
-	if p.memoize && !isLeftRecusion {
+	if p.memoize && !isLeftRecursion {
 		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
 	}
 	return val, ok

--- a/test/left_recursion/standart/withoutleftrecursion/without_left_recursion.go
+++ b/test/left_recursion/standart/withoutleftrecursion/without_left_recursion.go
@@ -319,7 +319,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/left_recursion_labeled_failures/left_recursion_labeled_failures.go
+++ b/test/left_recursion_labeled_failures/left_recursion_labeled_failures.go
@@ -373,7 +373,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -1304,8 +1304,8 @@ func (p *parser) parseRule(rule *rule) (any, bool) {
 func (p *parser) parseExprWrap(expr any) (any, bool) {
 	var pt savepoint
 
-	isLeftRecusion := p.rstack[len(p.rstack)-1].leftRecursive
-	if p.memoize && !isLeftRecusion {
+	isLeftRecursion := p.rstack[len(p.rstack)-1].leftRecursive
+	if p.memoize && !isLeftRecursion {
 		res, ok := p.getMemoized(expr)
 		if ok {
 			p.restore(res.end)
@@ -1316,7 +1316,7 @@ func (p *parser) parseExprWrap(expr any) (any, bool) {
 
 	val, ok := p.parseExpr(expr)
 
-	if p.memoize && !isLeftRecusion {
+	if p.memoize && !isLeftRecursion {
 		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
 	}
 	return val, ok

--- a/test/left_recursion_state/optimized/left_recursion_state.go
+++ b/test/left_recursion_state/optimized/left_recursion_state.go
@@ -383,7 +383,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/left_recursion_state/standart/left_recursion_state.go
+++ b/test/left_recursion_state/standart/left_recursion_state.go
@@ -383,7 +383,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -1314,8 +1314,8 @@ func (p *parser) parseRule(rule *rule) (any, bool) {
 func (p *parser) parseExprWrap(expr any) (any, bool) {
 	var pt savepoint
 
-	isLeftRecusion := p.rstack[len(p.rstack)-1].leftRecursive
-	if p.memoize && !isLeftRecusion {
+	isLeftRecursion := p.rstack[len(p.rstack)-1].leftRecursive
+	if p.memoize && !isLeftRecursion {
 		res, ok := p.getMemoized(expr)
 		if ok {
 			p.restore(res.end)
@@ -1326,7 +1326,7 @@ func (p *parser) parseExprWrap(expr any) (any, bool) {
 
 	val, ok := p.parseExpr(expr)
 
-	if p.memoize && !isLeftRecusion {
+	if p.memoize && !isLeftRecursion {
 		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
 	}
 	return val, ok

--- a/test/left_recursion_thrownrecover/left_recursion_thrownrecover.go
+++ b/test/left_recursion_thrownrecover/left_recursion_thrownrecover.go
@@ -953,7 +953,7 @@ func (p *parser) callonErrNonNumber1() (any, error) {
 }
 
 func (c *current) oncase023() (bool, error) {
-	return false, errors.New("Throwed undefined label")
+	return false, errors.New("Threw undefined label")
 }
 
 func (p *parser) calloncase023() (bool, error) {
@@ -1206,7 +1206,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -2137,8 +2137,8 @@ func (p *parser) parseRule(rule *rule) (any, bool) {
 func (p *parser) parseExprWrap(expr any) (any, bool) {
 	var pt savepoint
 
-	isLeftRecusion := p.rstack[len(p.rstack)-1].leftRecursive
-	if p.memoize && !isLeftRecusion {
+	isLeftRecursion := p.rstack[len(p.rstack)-1].leftRecursive
+	if p.memoize && !isLeftRecursion {
 		res, ok := p.getMemoized(expr)
 		if ok {
 			p.restore(res.end)
@@ -2149,7 +2149,7 @@ func (p *parser) parseExprWrap(expr any) (any, bool) {
 
 	val, ok := p.parseExpr(expr)
 
-	if p.memoize && !isLeftRecusion {
+	if p.memoize && !isLeftRecursion {
 		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
 	}
 	return val, ok

--- a/test/left_recursion_thrownrecover/left_recursion_thrownrecover.go
+++ b/test/left_recursion_thrownrecover/left_recursion_thrownrecover.go
@@ -49,15 +49,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLabelRecover",
-			pos:  position{line: 13, col: 1, offset: 167},
+			pos:  position{line: 13, col: 1, offset: 166},
 			expr: &recoveryExpr{
-				pos: position{line: 13, col: 21, offset: 187},
+				pos: position{line: 13, col: 21, offset: 186},
 				expr: &ruleRefExpr{
-					pos:  position{line: 13, col: 21, offset: 187},
+					pos:  position{line: 13, col: 21, offset: 186},
 					name: "number",
 				},
 				recoverExpr: &ruleRefExpr{
-					pos:  position{line: 13, col: 51, offset: 217},
+					pos:  position{line: 13, col: 51, offset: 216},
 					name: "ErrNonNumber",
 				},
 				failureLabel: []string{
@@ -70,35 +70,35 @@ var g = &grammar{
 		},
 		{
 			name: "number",
-			pos:  position{line: 15, col: 1, offset: 231},
+			pos:  position{line: 15, col: 1, offset: 230},
 			expr: &choiceExpr{
-				pos: position{line: 15, col: 10, offset: 240},
+				pos: position{line: 15, col: 10, offset: 239},
 				alternatives: []any{
 					&notExpr{
-						pos: position{line: 15, col: 10, offset: 240},
+						pos: position{line: 15, col: 10, offset: 239},
 						expr: &anyMatcher{
-							line: 15, col: 11, offset: 241,
+							line: 15, col: 11, offset: 240,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 15, col: 15, offset: 245},
+						pos: position{line: 15, col: 15, offset: 244},
 						run: (*parser).callonnumber4,
 						expr: &seqExpr{
-							pos: position{line: 15, col: 16, offset: 246},
+							pos: position{line: 15, col: 16, offset: 245},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 15, col: 16, offset: 246},
+									pos:   position{line: 15, col: 16, offset: 245},
 									label: "n",
 									expr: &ruleRefExpr{
-										pos:  position{line: 15, col: 18, offset: 248},
+										pos:  position{line: 15, col: 18, offset: 247},
 										name: "number",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 15, col: 25, offset: 255},
+									pos:   position{line: 15, col: 25, offset: 254},
 									label: "d",
 									expr: &ruleRefExpr{
-										pos:  position{line: 15, col: 27, offset: 257},
+										pos:  position{line: 15, col: 27, offset: 256},
 										name: "digit",
 									},
 								},
@@ -106,13 +106,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 17, col: 5, offset: 310},
+						pos: position{line: 17, col: 5, offset: 309},
 						run: (*parser).callonnumber10,
 						expr: &labeledExpr{
-							pos:   position{line: 17, col: 5, offset: 310},
+							pos:   position{line: 17, col: 5, offset: 309},
 							label: "d",
 							expr: &ruleRefExpr{
-								pos:  position{line: 17, col: 7, offset: 312},
+								pos:  position{line: 17, col: 7, offset: 311},
 								name: "digit",
 							},
 						},
@@ -124,15 +124,15 @@ var g = &grammar{
 		},
 		{
 			name: "digit",
-			pos:  position{line: 21, col: 1, offset: 350},
+			pos:  position{line: 21, col: 1, offset: 349},
 			expr: &choiceExpr{
-				pos: position{line: 21, col: 9, offset: 358},
+				pos: position{line: 21, col: 9, offset: 357},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 21, col: 9, offset: 358},
+						pos: position{line: 21, col: 9, offset: 357},
 						run: (*parser).callondigit2,
 						expr: &charClassMatcher{
-							pos:        position{line: 21, col: 9, offset: 358},
+							pos:        position{line: 21, col: 9, offset: 357},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -140,18 +140,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 23, col: 5, offset: 401},
+						pos: position{line: 23, col: 5, offset: 400},
 						run: (*parser).callondigit4,
 						expr: &labeledExpr{
-							pos:   position{line: 23, col: 5, offset: 401},
+							pos:   position{line: 23, col: 5, offset: 400},
 							label: "x",
 							expr: &seqExpr{
-								pos: position{line: 23, col: 9, offset: 405},
+								pos: position{line: 23, col: 9, offset: 404},
 								exprs: []any{
 									&andExpr{
-										pos: position{line: 23, col: 9, offset: 405},
+										pos: position{line: 23, col: 9, offset: 404},
 										expr: &charClassMatcher{
-											pos:        position{line: 23, col: 10, offset: 406},
+											pos:        position{line: 23, col: 10, offset: 405},
 											val:        "[a-z]",
 											ranges:     []rune{'a', 'z'},
 											ignoreCase: false,
@@ -159,7 +159,7 @@ var g = &grammar{
 										},
 									},
 									&throwExpr{
-										pos:   position{line: 23, col: 16, offset: 412},
+										pos:   position{line: 23, col: 16, offset: 411},
 										label: "errAlpha",
 									},
 								},
@@ -167,7 +167,7 @@ var g = &grammar{
 						},
 					},
 					&throwExpr{
-						pos:   position{line: 25, col: 5, offset: 461},
+						pos:   position{line: 25, col: 5, offset: 460},
 						label: "errOther",
 					},
 				},
@@ -177,26 +177,26 @@ var g = &grammar{
 		},
 		{
 			name: "ErrNonNumber",
-			pos:  position{line: 27, col: 1, offset: 474},
+			pos:  position{line: 27, col: 1, offset: 473},
 			expr: &actionExpr{
-				pos: position{line: 27, col: 16, offset: 489},
+				pos: position{line: 27, col: 16, offset: 488},
 				run: (*parser).callonErrNonNumber1,
 				expr: &seqExpr{
-					pos: position{line: 27, col: 16, offset: 489},
+					pos: position{line: 27, col: 16, offset: 488},
 					exprs: []any{
 						&andCodeExpr{
-							pos: position{line: 27, col: 16, offset: 489},
+							pos: position{line: 27, col: 16, offset: 488},
 							run: (*parser).callonErrNonNumber3,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 29, col: 3, offset: 544},
+							pos: position{line: 29, col: 3, offset: 543},
 							expr: &seqExpr{
-								pos: position{line: 29, col: 5, offset: 546},
+								pos: position{line: 29, col: 5, offset: 545},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 29, col: 5, offset: 546},
+										pos: position{line: 29, col: 5, offset: 545},
 										expr: &charClassMatcher{
-											pos:        position{line: 29, col: 6, offset: 547},
+											pos:        position{line: 29, col: 6, offset: 546},
 											val:        "[0-9]",
 											ranges:     []rune{'0', '9'},
 											ignoreCase: false,
@@ -204,7 +204,7 @@ var g = &grammar{
 										},
 									},
 									&anyMatcher{
-										line: 29, col: 12, offset: 553,
+										line: 29, col: 12, offset: 552,
 									},
 								},
 							},
@@ -217,16 +217,16 @@ var g = &grammar{
 		},
 		{
 			name: "case02",
-			pos:  position{line: 34, col: 1, offset: 615},
+			pos:  position{line: 34, col: 1, offset: 614},
 			expr: &choiceExpr{
-				pos: position{line: 34, col: 11, offset: 625},
+				pos: position{line: 34, col: 11, offset: 624},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 34, col: 11, offset: 625},
+						pos:  position{line: 34, col: 11, offset: 624},
 						name: "ThrowUndefLabel",
 					},
 					&andCodeExpr{
-						pos: position{line: 34, col: 29, offset: 643},
+						pos: position{line: 34, col: 29, offset: 642},
 						run: (*parser).calloncase023,
 					},
 				},
@@ -236,16 +236,16 @@ var g = &grammar{
 		},
 		{
 			name: "ThrowUndefLabel",
-			pos:  position{line: 36, col: 1, offset: 702},
+			pos:  position{line: 36, col: 1, offset: 699},
 			expr: &seqExpr{
-				pos: position{line: 36, col: 19, offset: 720},
+				pos: position{line: 36, col: 19, offset: 717},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 36, col: 19, offset: 720},
+						pos:  position{line: 36, col: 19, offset: 717},
 						name: "ThrowUndefLabel",
 					},
 					&throwExpr{
-						pos:   position{line: 36, col: 35, offset: 736},
+						pos:   position{line: 36, col: 35, offset: 733},
 						label: "undeflabel",
 					},
 				},
@@ -255,15 +255,15 @@ var g = &grammar{
 		},
 		{
 			name: "case03",
-			pos:  position{line: 41, col: 1, offset: 780},
+			pos:  position{line: 41, col: 1, offset: 777},
 			expr: &actionExpr{
-				pos: position{line: 41, col: 10, offset: 789},
+				pos: position{line: 41, col: 10, offset: 786},
 				run: (*parser).calloncase031,
 				expr: &labeledExpr{
-					pos:   position{line: 41, col: 10, offset: 789},
+					pos:   position{line: 41, col: 10, offset: 786},
 					label: "case03",
 					expr: &ruleRefExpr{
-						pos:  position{line: 41, col: 17, offset: 796},
+						pos:  position{line: 41, col: 17, offset: 793},
 						name: "OuterRecover03",
 					},
 				},
@@ -273,17 +273,17 @@ var g = &grammar{
 		},
 		{
 			name: "OuterRecover03",
-			pos:  position{line: 43, col: 1, offset: 835},
+			pos:  position{line: 43, col: 1, offset: 832},
 			expr: &recoveryExpr{
-				pos: position{line: 43, col: 18, offset: 852},
+				pos: position{line: 43, col: 18, offset: 849},
 				expr: &recoveryExpr{
-					pos: position{line: 43, col: 18, offset: 852},
+					pos: position{line: 43, col: 18, offset: 849},
 					expr: &ruleRefExpr{
-						pos:  position{line: 43, col: 18, offset: 852},
+						pos:  position{line: 43, col: 18, offset: 849},
 						name: "InnerRecover03",
 					},
 					recoverExpr: &ruleRefExpr{
-						pos:  position{line: 43, col: 66, offset: 900},
+						pos:  position{line: 43, col: 66, offset: 897},
 						name: "ErrAlphaOuter03",
 					},
 					failureLabel: []string{
@@ -292,7 +292,7 @@ var g = &grammar{
 					},
 				},
 				recoverExpr: &ruleRefExpr{
-					pos:  position{line: 43, col: 95, offset: 929},
+					pos:  position{line: 43, col: 95, offset: 926},
 					name: "ErrOtherOuter03",
 				},
 				failureLabel: []string{
@@ -304,15 +304,15 @@ var g = &grammar{
 		},
 		{
 			name: "InnerRecover03",
-			pos:  position{line: 45, col: 1, offset: 946},
+			pos:  position{line: 45, col: 1, offset: 943},
 			expr: &recoveryExpr{
-				pos: position{line: 45, col: 18, offset: 963},
+				pos: position{line: 45, col: 18, offset: 960},
 				expr: &ruleRefExpr{
-					pos:  position{line: 45, col: 18, offset: 963},
+					pos:  position{line: 45, col: 18, offset: 960},
 					name: "number03",
 				},
 				recoverExpr: &ruleRefExpr{
-					pos:  position{line: 45, col: 45, offset: 990},
+					pos:  position{line: 45, col: 45, offset: 987},
 					name: "ErrAlphaInner03",
 				},
 				failureLabel: []string{
@@ -324,35 +324,35 @@ var g = &grammar{
 		},
 		{
 			name: "number03",
-			pos:  position{line: 47, col: 1, offset: 1007},
+			pos:  position{line: 47, col: 1, offset: 1004},
 			expr: &choiceExpr{
-				pos: position{line: 47, col: 12, offset: 1018},
+				pos: position{line: 47, col: 12, offset: 1015},
 				alternatives: []any{
 					&notExpr{
-						pos: position{line: 47, col: 12, offset: 1018},
+						pos: position{line: 47, col: 12, offset: 1015},
 						expr: &anyMatcher{
-							line: 47, col: 13, offset: 1019,
+							line: 47, col: 13, offset: 1016,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 47, col: 17, offset: 1023},
+						pos: position{line: 47, col: 17, offset: 1020},
 						run: (*parser).callonnumber034,
 						expr: &seqExpr{
-							pos: position{line: 47, col: 18, offset: 1024},
+							pos: position{line: 47, col: 18, offset: 1021},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 47, col: 18, offset: 1024},
+									pos:   position{line: 47, col: 18, offset: 1021},
 									label: "n",
 									expr: &ruleRefExpr{
-										pos:  position{line: 47, col: 20, offset: 1026},
+										pos:  position{line: 47, col: 20, offset: 1023},
 										name: "number03",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 47, col: 29, offset: 1035},
+									pos:   position{line: 47, col: 29, offset: 1032},
 									label: "d",
 									expr: &ruleRefExpr{
-										pos:  position{line: 47, col: 31, offset: 1037},
+										pos:  position{line: 47, col: 31, offset: 1034},
 										name: "digit03",
 									},
 								},
@@ -360,13 +360,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 49, col: 5, offset: 1092},
+						pos: position{line: 49, col: 5, offset: 1089},
 						run: (*parser).callonnumber0310,
 						expr: &labeledExpr{
-							pos:   position{line: 49, col: 5, offset: 1092},
+							pos:   position{line: 49, col: 5, offset: 1089},
 							label: "d",
 							expr: &ruleRefExpr{
-								pos:  position{line: 49, col: 7, offset: 1094},
+								pos:  position{line: 49, col: 7, offset: 1091},
 								name: "digit03",
 							},
 						},
@@ -378,15 +378,15 @@ var g = &grammar{
 		},
 		{
 			name: "digit03",
-			pos:  position{line: 53, col: 1, offset: 1134},
+			pos:  position{line: 53, col: 1, offset: 1131},
 			expr: &choiceExpr{
-				pos: position{line: 53, col: 11, offset: 1144},
+				pos: position{line: 53, col: 11, offset: 1141},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 53, col: 11, offset: 1144},
+						pos: position{line: 53, col: 11, offset: 1141},
 						run: (*parser).callondigit032,
 						expr: &charClassMatcher{
-							pos:        position{line: 53, col: 11, offset: 1144},
+							pos:        position{line: 53, col: 11, offset: 1141},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -394,18 +394,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 55, col: 5, offset: 1187},
+						pos: position{line: 55, col: 5, offset: 1184},
 						run: (*parser).callondigit034,
 						expr: &labeledExpr{
-							pos:   position{line: 55, col: 5, offset: 1187},
+							pos:   position{line: 55, col: 5, offset: 1184},
 							label: "x",
 							expr: &seqExpr{
-								pos: position{line: 55, col: 9, offset: 1191},
+								pos: position{line: 55, col: 9, offset: 1188},
 								exprs: []any{
 									&andExpr{
-										pos: position{line: 55, col: 9, offset: 1191},
+										pos: position{line: 55, col: 9, offset: 1188},
 										expr: &charClassMatcher{
-											pos:        position{line: 55, col: 10, offset: 1192},
+											pos:        position{line: 55, col: 10, offset: 1189},
 											val:        "[a-z]",
 											ranges:     []rune{'a', 'z'},
 											ignoreCase: false,
@@ -413,7 +413,7 @@ var g = &grammar{
 										},
 									},
 									&throwExpr{
-										pos:   position{line: 55, col: 16, offset: 1198},
+										pos:   position{line: 55, col: 16, offset: 1195},
 										label: "errAlphaLower",
 									},
 								},
@@ -421,18 +421,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 57, col: 5, offset: 1252},
+						pos: position{line: 57, col: 5, offset: 1249},
 						run: (*parser).callondigit0310,
 						expr: &labeledExpr{
-							pos:   position{line: 57, col: 5, offset: 1252},
+							pos:   position{line: 57, col: 5, offset: 1249},
 							label: "x",
 							expr: &seqExpr{
-								pos: position{line: 57, col: 9, offset: 1256},
+								pos: position{line: 57, col: 9, offset: 1253},
 								exprs: []any{
 									&andExpr{
-										pos: position{line: 57, col: 9, offset: 1256},
+										pos: position{line: 57, col: 9, offset: 1253},
 										expr: &charClassMatcher{
-											pos:        position{line: 57, col: 10, offset: 1257},
+											pos:        position{line: 57, col: 10, offset: 1254},
 											val:        "[A-Z]",
 											ranges:     []rune{'A', 'Z'},
 											ignoreCase: false,
@@ -440,7 +440,7 @@ var g = &grammar{
 										},
 									},
 									&throwExpr{
-										pos:   position{line: 57, col: 16, offset: 1263},
+										pos:   position{line: 57, col: 16, offset: 1260},
 										label: "errAlphaUpper",
 									},
 								},
@@ -448,7 +448,7 @@ var g = &grammar{
 						},
 					},
 					&throwExpr{
-						pos:   position{line: 59, col: 5, offset: 1317},
+						pos:   position{line: 59, col: 5, offset: 1314},
 						label: "errOther",
 					},
 				},
@@ -458,26 +458,26 @@ var g = &grammar{
 		},
 		{
 			name: "ErrAlphaInner03",
-			pos:  position{line: 61, col: 1, offset: 1330},
+			pos:  position{line: 61, col: 1, offset: 1327},
 			expr: &actionExpr{
-				pos: position{line: 61, col: 19, offset: 1348},
+				pos: position{line: 61, col: 19, offset: 1345},
 				run: (*parser).callonErrAlphaInner031,
 				expr: &seqExpr{
-					pos: position{line: 61, col: 19, offset: 1348},
+					pos: position{line: 61, col: 19, offset: 1345},
 					exprs: []any{
 						&andCodeExpr{
-							pos: position{line: 61, col: 19, offset: 1348},
+							pos: position{line: 61, col: 19, offset: 1345},
 							run: (*parser).callonErrAlphaInner033,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 63, col: 3, offset: 1424},
+							pos: position{line: 63, col: 3, offset: 1421},
 							expr: &seqExpr{
-								pos: position{line: 63, col: 5, offset: 1426},
+								pos: position{line: 63, col: 5, offset: 1423},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 63, col: 5, offset: 1426},
+										pos: position{line: 63, col: 5, offset: 1423},
 										expr: &charClassMatcher{
-											pos:        position{line: 63, col: 6, offset: 1427},
+											pos:        position{line: 63, col: 6, offset: 1424},
 											val:        "[0-9]",
 											ranges:     []rune{'0', '9'},
 											ignoreCase: false,
@@ -485,7 +485,7 @@ var g = &grammar{
 										},
 									},
 									&anyMatcher{
-										line: 63, col: 12, offset: 1433,
+										line: 63, col: 12, offset: 1430,
 									},
 								},
 							},
@@ -498,26 +498,26 @@ var g = &grammar{
 		},
 		{
 			name: "ErrAlphaOuter03",
-			pos:  position{line: 65, col: 1, offset: 1459},
+			pos:  position{line: 65, col: 1, offset: 1456},
 			expr: &actionExpr{
-				pos: position{line: 65, col: 19, offset: 1477},
+				pos: position{line: 65, col: 19, offset: 1474},
 				run: (*parser).callonErrAlphaOuter031,
 				expr: &seqExpr{
-					pos: position{line: 65, col: 19, offset: 1477},
+					pos: position{line: 65, col: 19, offset: 1474},
 					exprs: []any{
 						&andCodeExpr{
-							pos: position{line: 65, col: 19, offset: 1477},
+							pos: position{line: 65, col: 19, offset: 1474},
 							run: (*parser).callonErrAlphaOuter033,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 67, col: 3, offset: 1553},
+							pos: position{line: 67, col: 3, offset: 1550},
 							expr: &seqExpr{
-								pos: position{line: 67, col: 5, offset: 1555},
+								pos: position{line: 67, col: 5, offset: 1552},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 67, col: 5, offset: 1555},
+										pos: position{line: 67, col: 5, offset: 1552},
 										expr: &charClassMatcher{
-											pos:        position{line: 67, col: 6, offset: 1556},
+											pos:        position{line: 67, col: 6, offset: 1553},
 											val:        "[0-9]",
 											ranges:     []rune{'0', '9'},
 											ignoreCase: false,
@@ -525,7 +525,7 @@ var g = &grammar{
 										},
 									},
 									&anyMatcher{
-										line: 67, col: 12, offset: 1562,
+										line: 67, col: 12, offset: 1559,
 									},
 								},
 							},
@@ -538,26 +538,26 @@ var g = &grammar{
 		},
 		{
 			name: "ErrOtherOuter03",
-			pos:  position{line: 69, col: 1, offset: 1588},
+			pos:  position{line: 69, col: 1, offset: 1585},
 			expr: &actionExpr{
-				pos: position{line: 69, col: 19, offset: 1606},
+				pos: position{line: 69, col: 19, offset: 1603},
 				run: (*parser).callonErrOtherOuter031,
 				expr: &seqExpr{
-					pos: position{line: 69, col: 19, offset: 1606},
+					pos: position{line: 69, col: 19, offset: 1603},
 					exprs: []any{
 						&andCodeExpr{
-							pos: position{line: 69, col: 19, offset: 1606},
+							pos: position{line: 69, col: 19, offset: 1603},
 							run: (*parser).callonErrOtherOuter033,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 71, col: 3, offset: 1677},
+							pos: position{line: 71, col: 3, offset: 1674},
 							expr: &seqExpr{
-								pos: position{line: 71, col: 5, offset: 1679},
+								pos: position{line: 71, col: 5, offset: 1676},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 71, col: 5, offset: 1679},
+										pos: position{line: 71, col: 5, offset: 1676},
 										expr: &charClassMatcher{
-											pos:        position{line: 71, col: 6, offset: 1680},
+											pos:        position{line: 71, col: 6, offset: 1677},
 											val:        "[0-9]",
 											ranges:     []rune{'0', '9'},
 											ignoreCase: false,
@@ -565,7 +565,7 @@ var g = &grammar{
 										},
 									},
 									&anyMatcher{
-										line: 71, col: 12, offset: 1686,
+										line: 71, col: 12, offset: 1683,
 									},
 								},
 							},
@@ -578,15 +578,15 @@ var g = &grammar{
 		},
 		{
 			name: "case04",
-			pos:  position{line: 76, col: 1, offset: 1771},
+			pos:  position{line: 76, col: 1, offset: 1768},
 			expr: &actionExpr{
-				pos: position{line: 76, col: 10, offset: 1780},
+				pos: position{line: 76, col: 10, offset: 1777},
 				run: (*parser).calloncase041,
 				expr: &labeledExpr{
-					pos:   position{line: 76, col: 10, offset: 1780},
+					pos:   position{line: 76, col: 10, offset: 1777},
 					label: "case04",
 					expr: &ruleRefExpr{
-						pos:  position{line: 76, col: 17, offset: 1787},
+						pos:  position{line: 76, col: 17, offset: 1784},
 						name: "OuterRecover04",
 					},
 				},
@@ -596,17 +596,17 @@ var g = &grammar{
 		},
 		{
 			name: "OuterRecover04",
-			pos:  position{line: 78, col: 1, offset: 1826},
+			pos:  position{line: 78, col: 1, offset: 1823},
 			expr: &recoveryExpr{
-				pos: position{line: 78, col: 18, offset: 1843},
+				pos: position{line: 78, col: 18, offset: 1840},
 				expr: &recoveryExpr{
-					pos: position{line: 78, col: 18, offset: 1843},
+					pos: position{line: 78, col: 18, offset: 1840},
 					expr: &ruleRefExpr{
-						pos:  position{line: 78, col: 18, offset: 1843},
+						pos:  position{line: 78, col: 18, offset: 1840},
 						name: "InnerRecover04",
 					},
 					recoverExpr: &ruleRefExpr{
-						pos:  position{line: 78, col: 66, offset: 1891},
+						pos:  position{line: 78, col: 66, offset: 1888},
 						name: "ErrAlphaOuter04",
 					},
 					failureLabel: []string{
@@ -615,7 +615,7 @@ var g = &grammar{
 					},
 				},
 				recoverExpr: &ruleRefExpr{
-					pos:  position{line: 78, col: 95, offset: 1920},
+					pos:  position{line: 78, col: 95, offset: 1917},
 					name: "ErrOtherOuter04",
 				},
 				failureLabel: []string{
@@ -627,15 +627,15 @@ var g = &grammar{
 		},
 		{
 			name: "InnerRecover04",
-			pos:  position{line: 80, col: 1, offset: 1937},
+			pos:  position{line: 80, col: 1, offset: 1934},
 			expr: &recoveryExpr{
-				pos: position{line: 80, col: 18, offset: 1954},
+				pos: position{line: 80, col: 18, offset: 1951},
 				expr: &ruleRefExpr{
-					pos:  position{line: 80, col: 18, offset: 1954},
+					pos:  position{line: 80, col: 18, offset: 1951},
 					name: "number04",
 				},
 				recoverExpr: &ruleRefExpr{
-					pos:  position{line: 80, col: 45, offset: 1981},
+					pos:  position{line: 80, col: 45, offset: 1978},
 					name: "ErrAlphaInner04",
 				},
 				failureLabel: []string{
@@ -647,35 +647,35 @@ var g = &grammar{
 		},
 		{
 			name: "number04",
-			pos:  position{line: 82, col: 1, offset: 1998},
+			pos:  position{line: 82, col: 1, offset: 1995},
 			expr: &choiceExpr{
-				pos: position{line: 82, col: 12, offset: 2009},
+				pos: position{line: 82, col: 12, offset: 2006},
 				alternatives: []any{
 					&notExpr{
-						pos: position{line: 82, col: 12, offset: 2009},
+						pos: position{line: 82, col: 12, offset: 2006},
 						expr: &anyMatcher{
-							line: 82, col: 13, offset: 2010,
+							line: 82, col: 13, offset: 2007,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 82, col: 17, offset: 2014},
+						pos: position{line: 82, col: 17, offset: 2011},
 						run: (*parser).callonnumber044,
 						expr: &seqExpr{
-							pos: position{line: 82, col: 18, offset: 2015},
+							pos: position{line: 82, col: 18, offset: 2012},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 82, col: 18, offset: 2015},
+									pos:   position{line: 82, col: 18, offset: 2012},
 									label: "n",
 									expr: &ruleRefExpr{
-										pos:  position{line: 82, col: 20, offset: 2017},
+										pos:  position{line: 82, col: 20, offset: 2014},
 										name: "number04",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 82, col: 29, offset: 2026},
+									pos:   position{line: 82, col: 29, offset: 2023},
 									label: "d",
 									expr: &ruleRefExpr{
-										pos:  position{line: 82, col: 31, offset: 2028},
+										pos:  position{line: 82, col: 31, offset: 2025},
 										name: "digit04",
 									},
 								},
@@ -683,13 +683,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 84, col: 5, offset: 2083},
+						pos: position{line: 84, col: 5, offset: 2080},
 						run: (*parser).callonnumber0410,
 						expr: &labeledExpr{
-							pos:   position{line: 84, col: 5, offset: 2083},
+							pos:   position{line: 84, col: 5, offset: 2080},
 							label: "d",
 							expr: &ruleRefExpr{
-								pos:  position{line: 84, col: 7, offset: 2085},
+								pos:  position{line: 84, col: 7, offset: 2082},
 								name: "digit04",
 							},
 						},
@@ -701,15 +701,15 @@ var g = &grammar{
 		},
 		{
 			name: "digit04",
-			pos:  position{line: 88, col: 1, offset: 2125},
+			pos:  position{line: 88, col: 1, offset: 2122},
 			expr: &choiceExpr{
-				pos: position{line: 88, col: 11, offset: 2135},
+				pos: position{line: 88, col: 11, offset: 2132},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 88, col: 11, offset: 2135},
+						pos: position{line: 88, col: 11, offset: 2132},
 						run: (*parser).callondigit042,
 						expr: &charClassMatcher{
-							pos:        position{line: 88, col: 11, offset: 2135},
+							pos:        position{line: 88, col: 11, offset: 2132},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -717,18 +717,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 90, col: 5, offset: 2178},
+						pos: position{line: 90, col: 5, offset: 2175},
 						run: (*parser).callondigit044,
 						expr: &labeledExpr{
-							pos:   position{line: 90, col: 5, offset: 2178},
+							pos:   position{line: 90, col: 5, offset: 2175},
 							label: "x",
 							expr: &seqExpr{
-								pos: position{line: 90, col: 9, offset: 2182},
+								pos: position{line: 90, col: 9, offset: 2179},
 								exprs: []any{
 									&andExpr{
-										pos: position{line: 90, col: 9, offset: 2182},
+										pos: position{line: 90, col: 9, offset: 2179},
 										expr: &charClassMatcher{
-											pos:        position{line: 90, col: 10, offset: 2183},
+											pos:        position{line: 90, col: 10, offset: 2180},
 											val:        "[a-z]",
 											ranges:     []rune{'a', 'z'},
 											ignoreCase: false,
@@ -736,7 +736,7 @@ var g = &grammar{
 										},
 									},
 									&throwExpr{
-										pos:   position{line: 90, col: 16, offset: 2189},
+										pos:   position{line: 90, col: 16, offset: 2186},
 										label: "errAlphaLower",
 									},
 								},
@@ -744,18 +744,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 92, col: 5, offset: 2243},
+						pos: position{line: 92, col: 5, offset: 2240},
 						run: (*parser).callondigit0410,
 						expr: &labeledExpr{
-							pos:   position{line: 92, col: 5, offset: 2243},
+							pos:   position{line: 92, col: 5, offset: 2240},
 							label: "x",
 							expr: &seqExpr{
-								pos: position{line: 92, col: 9, offset: 2247},
+								pos: position{line: 92, col: 9, offset: 2244},
 								exprs: []any{
 									&andExpr{
-										pos: position{line: 92, col: 9, offset: 2247},
+										pos: position{line: 92, col: 9, offset: 2244},
 										expr: &charClassMatcher{
-											pos:        position{line: 92, col: 10, offset: 2248},
+											pos:        position{line: 92, col: 10, offset: 2245},
 											val:        "[A-Z]",
 											ranges:     []rune{'A', 'Z'},
 											ignoreCase: false,
@@ -763,7 +763,7 @@ var g = &grammar{
 										},
 									},
 									&throwExpr{
-										pos:   position{line: 92, col: 16, offset: 2254},
+										pos:   position{line: 92, col: 16, offset: 2251},
 										label: "errAlphaUpper",
 									},
 								},
@@ -771,7 +771,7 @@ var g = &grammar{
 						},
 					},
 					&throwExpr{
-						pos:   position{line: 94, col: 5, offset: 2308},
+						pos:   position{line: 94, col: 5, offset: 2305},
 						label: "errOther",
 					},
 				},
@@ -781,9 +781,9 @@ var g = &grammar{
 		},
 		{
 			name: "ErrAlphaInner04",
-			pos:  position{line: 96, col: 1, offset: 2321},
+			pos:  position{line: 96, col: 1, offset: 2318},
 			expr: &andCodeExpr{
-				pos: position{line: 96, col: 19, offset: 2339},
+				pos: position{line: 96, col: 19, offset: 2336},
 				run: (*parser).callonErrAlphaInner041,
 			},
 			leader:        false,
@@ -791,26 +791,26 @@ var g = &grammar{
 		},
 		{
 			name: "ErrAlphaOuter04",
-			pos:  position{line: 100, col: 1, offset: 2367},
+			pos:  position{line: 100, col: 1, offset: 2364},
 			expr: &actionExpr{
-				pos: position{line: 100, col: 19, offset: 2385},
+				pos: position{line: 100, col: 19, offset: 2382},
 				run: (*parser).callonErrAlphaOuter041,
 				expr: &seqExpr{
-					pos: position{line: 100, col: 19, offset: 2385},
+					pos: position{line: 100, col: 19, offset: 2382},
 					exprs: []any{
 						&andCodeExpr{
-							pos: position{line: 100, col: 19, offset: 2385},
+							pos: position{line: 100, col: 19, offset: 2382},
 							run: (*parser).callonErrAlphaOuter043,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 102, col: 3, offset: 2452},
+							pos: position{line: 102, col: 3, offset: 2449},
 							expr: &seqExpr{
-								pos: position{line: 102, col: 5, offset: 2454},
+								pos: position{line: 102, col: 5, offset: 2451},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 102, col: 5, offset: 2454},
+										pos: position{line: 102, col: 5, offset: 2451},
 										expr: &charClassMatcher{
-											pos:        position{line: 102, col: 6, offset: 2455},
+											pos:        position{line: 102, col: 6, offset: 2452},
 											val:        "[0-9]",
 											ranges:     []rune{'0', '9'},
 											ignoreCase: false,
@@ -818,7 +818,7 @@ var g = &grammar{
 										},
 									},
 									&anyMatcher{
-										line: 102, col: 12, offset: 2461,
+										line: 102, col: 12, offset: 2458,
 									},
 								},
 							},
@@ -831,26 +831,26 @@ var g = &grammar{
 		},
 		{
 			name: "ErrOtherOuter04",
-			pos:  position{line: 104, col: 1, offset: 2487},
+			pos:  position{line: 104, col: 1, offset: 2484},
 			expr: &actionExpr{
-				pos: position{line: 104, col: 19, offset: 2505},
+				pos: position{line: 104, col: 19, offset: 2502},
 				run: (*parser).callonErrOtherOuter041,
 				expr: &seqExpr{
-					pos: position{line: 104, col: 19, offset: 2505},
+					pos: position{line: 104, col: 19, offset: 2502},
 					exprs: []any{
 						&andCodeExpr{
-							pos: position{line: 104, col: 19, offset: 2505},
+							pos: position{line: 104, col: 19, offset: 2502},
 							run: (*parser).callonErrOtherOuter043,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 106, col: 3, offset: 2576},
+							pos: position{line: 106, col: 3, offset: 2573},
 							expr: &seqExpr{
-								pos: position{line: 106, col: 5, offset: 2578},
+								pos: position{line: 106, col: 5, offset: 2575},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 106, col: 5, offset: 2578},
+										pos: position{line: 106, col: 5, offset: 2575},
 										expr: &charClassMatcher{
-											pos:        position{line: 106, col: 6, offset: 2579},
+											pos:        position{line: 106, col: 6, offset: 2576},
 											val:        "[0-9]",
 											ranges:     []rune{'0', '9'},
 											ignoreCase: false,
@@ -858,7 +858,7 @@ var g = &grammar{
 										},
 									},
 									&anyMatcher{
-										line: 106, col: 12, offset: 2585,
+										line: 106, col: 12, offset: 2582,
 									},
 								},
 							},

--- a/test/left_recursion_thrownrecover/left_recursion_thrownrecover.peg
+++ b/test/left_recursion_thrownrecover/left_recursion_thrownrecover.peg
@@ -8,7 +8,7 @@ Start = &{return false, nil}
 
 // Case 01: Multiple Label Recover
 
-case01 = case01:MultiLabelRecover { return case01, nil } 
+case01 = case01:MultiLabelRecover { return case01, nil }
 
 MultiLabelRecover = number //{errAlpha, errOther} ErrNonNumber
 
@@ -31,7 +31,7 @@ ErrNonNumber = &{
 
 // Case 02: Throw Undefined Label
 
-case02 = (ThrowUndefLabel / &{ return false, errors.New("Throwed undefined label") })
+case02 = (ThrowUndefLabel / &{ return false, errors.New("Threw undefined label") })
 
 ThrowUndefLabel = ThrowUndefLabel %{undeflabel}
 

--- a/test/left_recursion_thrownrecover/left_recursion_thrownrecover_test.go
+++ b/test/left_recursion_thrownrecover/left_recursion_thrownrecover_test.go
@@ -60,7 +60,7 @@ func TestLeftRecursionWithThrowAndRecover(t *testing.T) {
 			want: want{
 				captures: nil,
 				errors: []string{
-					"1:1 (0): rule case02: Throwed undefined label",
+					"1:1 (0): rule case02: Threw undefined label",
 				},
 			},
 		},

--- a/test/linear/linear.go
+++ b/test/linear/linear.go
@@ -209,7 +209,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/max_expr_cnt/maxexpr.go
+++ b/test/max_expr_cnt/maxexpr.go
@@ -86,7 +86,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/predicates/predicates.go
+++ b/test/predicates/predicates.go
@@ -263,7 +263,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/runeerror/runeerror.go
+++ b/test/runeerror/runeerror.go
@@ -108,7 +108,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -191,7 +191,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/stateclone/stateclone.go
+++ b/test/stateclone/stateclone.go
@@ -281,7 +281,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/statereadonly/statereadonly.go
+++ b/test/statereadonly/statereadonly.go
@@ -262,7 +262,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/staterestore/optimized/staterestore.go
+++ b/test/staterestore/optimized/staterestore.go
@@ -693,7 +693,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/staterestore/standard/staterestore.go
+++ b/test/staterestore/standard/staterestore.go
@@ -361,7 +361,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/staterestore/staterestore.go
+++ b/test/staterestore/staterestore.go
@@ -361,7 +361,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -73,15 +73,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLabelRecover",
-			pos:  position{line: 13, col: 1, offset: 177},
+			pos:  position{line: 13, col: 1, offset: 176},
 			expr: &recoveryExpr{
-				pos: position{line: 13, col: 21, offset: 197},
+				pos: position{line: 13, col: 21, offset: 196},
 				expr: &ruleRefExpr{
-					pos:  position{line: 13, col: 21, offset: 197},
+					pos:  position{line: 13, col: 21, offset: 196},
 					name: "number",
 				},
 				recoverExpr: &ruleRefExpr{
-					pos:  position{line: 13, col: 51, offset: 227},
+					pos:  position{line: 13, col: 51, offset: 226},
 					name: "ErrNonNumber",
 				},
 				failureLabel: []string{
@@ -92,35 +92,35 @@ var g = &grammar{
 		},
 		{
 			name: "number",
-			pos:  position{line: 15, col: 1, offset: 241},
+			pos:  position{line: 15, col: 1, offset: 240},
 			expr: &choiceExpr{
-				pos: position{line: 15, col: 10, offset: 250},
+				pos: position{line: 15, col: 10, offset: 249},
 				alternatives: []any{
 					&notExpr{
-						pos: position{line: 15, col: 10, offset: 250},
+						pos: position{line: 15, col: 10, offset: 249},
 						expr: &anyMatcher{
-							line: 15, col: 11, offset: 251,
+							line: 15, col: 11, offset: 250,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 15, col: 15, offset: 255},
+						pos: position{line: 15, col: 15, offset: 254},
 						run: (*parser).callonnumber4,
 						expr: &seqExpr{
-							pos: position{line: 15, col: 15, offset: 255},
+							pos: position{line: 15, col: 15, offset: 254},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 15, col: 15, offset: 255},
+									pos:   position{line: 15, col: 15, offset: 254},
 									label: "d",
 									expr: &ruleRefExpr{
-										pos:  position{line: 15, col: 17, offset: 257},
+										pos:  position{line: 15, col: 17, offset: 256},
 										name: "digit",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 15, col: 23, offset: 263},
+									pos:   position{line: 15, col: 23, offset: 262},
 									label: "n",
 									expr: &ruleRefExpr{
-										pos:  position{line: 15, col: 25, offset: 265},
+										pos:  position{line: 15, col: 25, offset: 264},
 										name: "number",
 									},
 								},
@@ -132,15 +132,15 @@ var g = &grammar{
 		},
 		{
 			name: "digit",
-			pos:  position{line: 22, col: 1, offset: 372},
+			pos:  position{line: 22, col: 1, offset: 371},
 			expr: &choiceExpr{
-				pos: position{line: 22, col: 9, offset: 380},
+				pos: position{line: 22, col: 9, offset: 379},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 22, col: 9, offset: 380},
+						pos: position{line: 22, col: 9, offset: 379},
 						run: (*parser).callondigit2,
 						expr: &charClassMatcher{
-							pos:        position{line: 22, col: 9, offset: 380},
+							pos:        position{line: 22, col: 9, offset: 379},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -148,18 +148,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 22, col: 48, offset: 419},
+						pos: position{line: 22, col: 48, offset: 418},
 						run: (*parser).callondigit4,
 						expr: &labeledExpr{
-							pos:   position{line: 22, col: 48, offset: 419},
+							pos:   position{line: 22, col: 48, offset: 418},
 							label: "x",
 							expr: &seqExpr{
-								pos: position{line: 22, col: 52, offset: 423},
+								pos: position{line: 22, col: 52, offset: 422},
 								exprs: []any{
 									&andExpr{
-										pos: position{line: 22, col: 52, offset: 423},
+										pos: position{line: 22, col: 52, offset: 422},
 										expr: &charClassMatcher{
-											pos:        position{line: 22, col: 53, offset: 424},
+											pos:        position{line: 22, col: 53, offset: 423},
 											val:        "[a-z]",
 											ranges:     []rune{'a', 'z'},
 											ignoreCase: false,
@@ -167,7 +167,7 @@ var g = &grammar{
 										},
 									},
 									&throwExpr{
-										pos:   position{line: 22, col: 59, offset: 430},
+										pos:   position{line: 22, col: 59, offset: 429},
 										label: "errAlpha",
 									},
 								},
@@ -175,7 +175,7 @@ var g = &grammar{
 						},
 					},
 					&throwExpr{
-						pos:   position{line: 22, col: 104, offset: 475},
+						pos:   position{line: 22, col: 104, offset: 474},
 						label: "errOther",
 					},
 				},
@@ -183,26 +183,26 @@ var g = &grammar{
 		},
 		{
 			name: "ErrNonNumber",
-			pos:  position{line: 24, col: 1, offset: 488},
+			pos:  position{line: 24, col: 1, offset: 487},
 			expr: &actionExpr{
-				pos: position{line: 24, col: 16, offset: 503},
+				pos: position{line: 24, col: 16, offset: 502},
 				run: (*parser).callonErrNonNumber1,
 				expr: &seqExpr{
-					pos: position{line: 24, col: 16, offset: 503},
+					pos: position{line: 24, col: 16, offset: 502},
 					exprs: []any{
 						&andCodeExpr{
-							pos: position{line: 24, col: 16, offset: 503},
+							pos: position{line: 24, col: 16, offset: 502},
 							run: (*parser).callonErrNonNumber3,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 26, col: 3, offset: 558},
+							pos: position{line: 26, col: 3, offset: 557},
 							expr: &seqExpr{
-								pos: position{line: 26, col: 5, offset: 560},
+								pos: position{line: 26, col: 5, offset: 559},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 26, col: 5, offset: 560},
+										pos: position{line: 26, col: 5, offset: 559},
 										expr: &charClassMatcher{
-											pos:        position{line: 26, col: 6, offset: 561},
+											pos:        position{line: 26, col: 6, offset: 560},
 											val:        "[0-9]",
 											ranges:     []rune{'0', '9'},
 											ignoreCase: false,
@@ -210,7 +210,7 @@ var g = &grammar{
 										},
 									},
 									&anyMatcher{
-										line: 26, col: 12, offset: 567,
+										line: 26, col: 12, offset: 566,
 									},
 								},
 							},
@@ -221,25 +221,25 @@ var g = &grammar{
 		},
 		{
 			name: "case02",
-			pos:  position{line: 31, col: 1, offset: 629},
+			pos:  position{line: 31, col: 1, offset: 628},
 			expr: &seqExpr{
-				pos: position{line: 31, col: 10, offset: 638},
+				pos: position{line: 31, col: 10, offset: 637},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 31, col: 10, offset: 638},
+						pos:        position{line: 31, col: 10, offset: 637},
 						val:        "case02:",
 						ignoreCase: false,
 						want:       "\"case02:\"",
 					},
 					&choiceExpr{
-						pos: position{line: 31, col: 21, offset: 649},
+						pos: position{line: 31, col: 21, offset: 648},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 31, col: 21, offset: 649},
+								pos:  position{line: 31, col: 21, offset: 648},
 								name: "ThrowUndefLabel",
 							},
 							&andCodeExpr{
-								pos: position{line: 31, col: 39, offset: 667},
+								pos: position{line: 31, col: 39, offset: 666},
 								run: (*parser).calloncase025,
 							},
 						},
@@ -249,32 +249,32 @@ var g = &grammar{
 		},
 		{
 			name: "ThrowUndefLabel",
-			pos:  position{line: 33, col: 1, offset: 726},
+			pos:  position{line: 33, col: 1, offset: 723},
 			expr: &throwExpr{
-				pos:   position{line: 33, col: 19, offset: 744},
+				pos:   position{line: 33, col: 19, offset: 741},
 				label: "undeflabel",
 			},
 		},
 		{
 			name: "case03",
-			pos:  position{line: 38, col: 1, offset: 788},
+			pos:  position{line: 38, col: 1, offset: 785},
 			expr: &actionExpr{
-				pos: position{line: 38, col: 10, offset: 797},
+				pos: position{line: 38, col: 10, offset: 794},
 				run: (*parser).calloncase031,
 				expr: &seqExpr{
-					pos: position{line: 38, col: 10, offset: 797},
+					pos: position{line: 38, col: 10, offset: 794},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 38, col: 10, offset: 797},
+							pos:        position{line: 38, col: 10, offset: 794},
 							val:        "case03:",
 							ignoreCase: false,
 							want:       "\"case03:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 38, col: 20, offset: 807},
+							pos:   position{line: 38, col: 20, offset: 804},
 							label: "case03",
 							expr: &ruleRefExpr{
-								pos:  position{line: 38, col: 27, offset: 814},
+								pos:  position{line: 38, col: 27, offset: 811},
 								name: "OuterRecover03",
 							},
 						},
@@ -284,17 +284,17 @@ var g = &grammar{
 		},
 		{
 			name: "OuterRecover03",
-			pos:  position{line: 40, col: 1, offset: 853},
+			pos:  position{line: 40, col: 1, offset: 850},
 			expr: &recoveryExpr{
-				pos: position{line: 40, col: 18, offset: 870},
+				pos: position{line: 40, col: 18, offset: 867},
 				expr: &recoveryExpr{
-					pos: position{line: 40, col: 18, offset: 870},
+					pos: position{line: 40, col: 18, offset: 867},
 					expr: &ruleRefExpr{
-						pos:  position{line: 40, col: 18, offset: 870},
+						pos:  position{line: 40, col: 18, offset: 867},
 						name: "InnerRecover03",
 					},
 					recoverExpr: &ruleRefExpr{
-						pos:  position{line: 40, col: 66, offset: 918},
+						pos:  position{line: 40, col: 66, offset: 915},
 						name: "ErrAlphaOuter03",
 					},
 					failureLabel: []string{
@@ -303,7 +303,7 @@ var g = &grammar{
 					},
 				},
 				recoverExpr: &ruleRefExpr{
-					pos:  position{line: 40, col: 95, offset: 947},
+					pos:  position{line: 40, col: 95, offset: 944},
 					name: "ErrOtherOuter03",
 				},
 				failureLabel: []string{
@@ -313,15 +313,15 @@ var g = &grammar{
 		},
 		{
 			name: "InnerRecover03",
-			pos:  position{line: 42, col: 1, offset: 964},
+			pos:  position{line: 42, col: 1, offset: 961},
 			expr: &recoveryExpr{
-				pos: position{line: 42, col: 18, offset: 981},
+				pos: position{line: 42, col: 18, offset: 978},
 				expr: &ruleRefExpr{
-					pos:  position{line: 42, col: 18, offset: 981},
+					pos:  position{line: 42, col: 18, offset: 978},
 					name: "number03",
 				},
 				recoverExpr: &ruleRefExpr{
-					pos:  position{line: 42, col: 45, offset: 1008},
+					pos:  position{line: 42, col: 45, offset: 1005},
 					name: "ErrAlphaInner03",
 				},
 				failureLabel: []string{
@@ -331,35 +331,35 @@ var g = &grammar{
 		},
 		{
 			name: "number03",
-			pos:  position{line: 44, col: 1, offset: 1025},
+			pos:  position{line: 44, col: 1, offset: 1022},
 			expr: &choiceExpr{
-				pos: position{line: 44, col: 12, offset: 1036},
+				pos: position{line: 44, col: 12, offset: 1033},
 				alternatives: []any{
 					&notExpr{
-						pos: position{line: 44, col: 12, offset: 1036},
+						pos: position{line: 44, col: 12, offset: 1033},
 						expr: &anyMatcher{
-							line: 44, col: 13, offset: 1037,
+							line: 44, col: 13, offset: 1034,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 44, col: 17, offset: 1041},
+						pos: position{line: 44, col: 17, offset: 1038},
 						run: (*parser).callonnumber034,
 						expr: &seqExpr{
-							pos: position{line: 44, col: 17, offset: 1041},
+							pos: position{line: 44, col: 17, offset: 1038},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 44, col: 17, offset: 1041},
+									pos:   position{line: 44, col: 17, offset: 1038},
 									label: "d",
 									expr: &ruleRefExpr{
-										pos:  position{line: 44, col: 19, offset: 1043},
+										pos:  position{line: 44, col: 19, offset: 1040},
 										name: "digit03",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 44, col: 27, offset: 1051},
+									pos:   position{line: 44, col: 27, offset: 1048},
 									label: "n",
 									expr: &ruleRefExpr{
-										pos:  position{line: 44, col: 29, offset: 1053},
+										pos:  position{line: 44, col: 29, offset: 1050},
 										name: "number03",
 									},
 								},
@@ -371,15 +371,15 @@ var g = &grammar{
 		},
 		{
 			name: "digit03",
-			pos:  position{line: 51, col: 1, offset: 1162},
+			pos:  position{line: 51, col: 1, offset: 1159},
 			expr: &choiceExpr{
-				pos: position{line: 51, col: 11, offset: 1172},
+				pos: position{line: 51, col: 11, offset: 1169},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 51, col: 11, offset: 1172},
+						pos: position{line: 51, col: 11, offset: 1169},
 						run: (*parser).callondigit032,
 						expr: &charClassMatcher{
-							pos:        position{line: 51, col: 11, offset: 1172},
+							pos:        position{line: 51, col: 11, offset: 1169},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -387,18 +387,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 51, col: 50, offset: 1211},
+						pos: position{line: 51, col: 50, offset: 1208},
 						run: (*parser).callondigit034,
 						expr: &labeledExpr{
-							pos:   position{line: 51, col: 50, offset: 1211},
+							pos:   position{line: 51, col: 50, offset: 1208},
 							label: "x",
 							expr: &seqExpr{
-								pos: position{line: 51, col: 54, offset: 1215},
+								pos: position{line: 51, col: 54, offset: 1212},
 								exprs: []any{
 									&andExpr{
-										pos: position{line: 51, col: 54, offset: 1215},
+										pos: position{line: 51, col: 54, offset: 1212},
 										expr: &charClassMatcher{
-											pos:        position{line: 51, col: 55, offset: 1216},
+											pos:        position{line: 51, col: 55, offset: 1213},
 											val:        "[a-z]",
 											ranges:     []rune{'a', 'z'},
 											ignoreCase: false,
@@ -406,7 +406,7 @@ var g = &grammar{
 										},
 									},
 									&throwExpr{
-										pos:   position{line: 51, col: 61, offset: 1222},
+										pos:   position{line: 51, col: 61, offset: 1219},
 										label: "errAlphaLower",
 									},
 								},
@@ -414,18 +414,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 51, col: 111, offset: 1272},
+						pos: position{line: 51, col: 111, offset: 1269},
 						run: (*parser).callondigit0310,
 						expr: &labeledExpr{
-							pos:   position{line: 51, col: 111, offset: 1272},
+							pos:   position{line: 51, col: 111, offset: 1269},
 							label: "x",
 							expr: &seqExpr{
-								pos: position{line: 51, col: 115, offset: 1276},
+								pos: position{line: 51, col: 115, offset: 1273},
 								exprs: []any{
 									&andExpr{
-										pos: position{line: 51, col: 115, offset: 1276},
+										pos: position{line: 51, col: 115, offset: 1273},
 										expr: &charClassMatcher{
-											pos:        position{line: 51, col: 116, offset: 1277},
+											pos:        position{line: 51, col: 116, offset: 1274},
 											val:        "[A-Z]",
 											ranges:     []rune{'A', 'Z'},
 											ignoreCase: false,
@@ -433,7 +433,7 @@ var g = &grammar{
 										},
 									},
 									&throwExpr{
-										pos:   position{line: 51, col: 122, offset: 1283},
+										pos:   position{line: 51, col: 122, offset: 1280},
 										label: "errAlphaUpper",
 									},
 								},
@@ -441,7 +441,7 @@ var g = &grammar{
 						},
 					},
 					&throwExpr{
-						pos:   position{line: 51, col: 172, offset: 1333},
+						pos:   position{line: 51, col: 172, offset: 1330},
 						label: "errOther",
 					},
 				},
@@ -449,26 +449,26 @@ var g = &grammar{
 		},
 		{
 			name: "ErrAlphaInner03",
-			pos:  position{line: 53, col: 1, offset: 1346},
+			pos:  position{line: 53, col: 1, offset: 1343},
 			expr: &actionExpr{
-				pos: position{line: 53, col: 19, offset: 1364},
+				pos: position{line: 53, col: 19, offset: 1361},
 				run: (*parser).callonErrAlphaInner031,
 				expr: &seqExpr{
-					pos: position{line: 53, col: 19, offset: 1364},
+					pos: position{line: 53, col: 19, offset: 1361},
 					exprs: []any{
 						&andCodeExpr{
-							pos: position{line: 53, col: 19, offset: 1364},
+							pos: position{line: 53, col: 19, offset: 1361},
 							run: (*parser).callonErrAlphaInner033,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 55, col: 3, offset: 1440},
+							pos: position{line: 55, col: 3, offset: 1437},
 							expr: &seqExpr{
-								pos: position{line: 55, col: 5, offset: 1442},
+								pos: position{line: 55, col: 5, offset: 1439},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 55, col: 5, offset: 1442},
+										pos: position{line: 55, col: 5, offset: 1439},
 										expr: &charClassMatcher{
-											pos:        position{line: 55, col: 6, offset: 1443},
+											pos:        position{line: 55, col: 6, offset: 1440},
 											val:        "[0-9]",
 											ranges:     []rune{'0', '9'},
 											ignoreCase: false,
@@ -476,7 +476,7 @@ var g = &grammar{
 										},
 									},
 									&anyMatcher{
-										line: 55, col: 12, offset: 1449,
+										line: 55, col: 12, offset: 1446,
 									},
 								},
 							},
@@ -487,26 +487,26 @@ var g = &grammar{
 		},
 		{
 			name: "ErrAlphaOuter03",
-			pos:  position{line: 57, col: 1, offset: 1475},
+			pos:  position{line: 57, col: 1, offset: 1472},
 			expr: &actionExpr{
-				pos: position{line: 57, col: 19, offset: 1493},
+				pos: position{line: 57, col: 19, offset: 1490},
 				run: (*parser).callonErrAlphaOuter031,
 				expr: &seqExpr{
-					pos: position{line: 57, col: 19, offset: 1493},
+					pos: position{line: 57, col: 19, offset: 1490},
 					exprs: []any{
 						&andCodeExpr{
-							pos: position{line: 57, col: 19, offset: 1493},
+							pos: position{line: 57, col: 19, offset: 1490},
 							run: (*parser).callonErrAlphaOuter033,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 59, col: 3, offset: 1569},
+							pos: position{line: 59, col: 3, offset: 1566},
 							expr: &seqExpr{
-								pos: position{line: 59, col: 5, offset: 1571},
+								pos: position{line: 59, col: 5, offset: 1568},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 59, col: 5, offset: 1571},
+										pos: position{line: 59, col: 5, offset: 1568},
 										expr: &charClassMatcher{
-											pos:        position{line: 59, col: 6, offset: 1572},
+											pos:        position{line: 59, col: 6, offset: 1569},
 											val:        "[0-9]",
 											ranges:     []rune{'0', '9'},
 											ignoreCase: false,
@@ -514,7 +514,7 @@ var g = &grammar{
 										},
 									},
 									&anyMatcher{
-										line: 59, col: 12, offset: 1578,
+										line: 59, col: 12, offset: 1575,
 									},
 								},
 							},
@@ -525,26 +525,26 @@ var g = &grammar{
 		},
 		{
 			name: "ErrOtherOuter03",
-			pos:  position{line: 61, col: 1, offset: 1604},
+			pos:  position{line: 61, col: 1, offset: 1601},
 			expr: &actionExpr{
-				pos: position{line: 61, col: 19, offset: 1622},
+				pos: position{line: 61, col: 19, offset: 1619},
 				run: (*parser).callonErrOtherOuter031,
 				expr: &seqExpr{
-					pos: position{line: 61, col: 19, offset: 1622},
+					pos: position{line: 61, col: 19, offset: 1619},
 					exprs: []any{
 						&andCodeExpr{
-							pos: position{line: 61, col: 19, offset: 1622},
+							pos: position{line: 61, col: 19, offset: 1619},
 							run: (*parser).callonErrOtherOuter033,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 63, col: 3, offset: 1693},
+							pos: position{line: 63, col: 3, offset: 1690},
 							expr: &seqExpr{
-								pos: position{line: 63, col: 5, offset: 1695},
+								pos: position{line: 63, col: 5, offset: 1692},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 63, col: 5, offset: 1695},
+										pos: position{line: 63, col: 5, offset: 1692},
 										expr: &charClassMatcher{
-											pos:        position{line: 63, col: 6, offset: 1696},
+											pos:        position{line: 63, col: 6, offset: 1693},
 											val:        "[0-9]",
 											ranges:     []rune{'0', '9'},
 											ignoreCase: false,
@@ -552,7 +552,7 @@ var g = &grammar{
 										},
 									},
 									&anyMatcher{
-										line: 63, col: 12, offset: 1702,
+										line: 63, col: 12, offset: 1699,
 									},
 								},
 							},
@@ -563,24 +563,24 @@ var g = &grammar{
 		},
 		{
 			name: "case04",
-			pos:  position{line: 68, col: 1, offset: 1787},
+			pos:  position{line: 68, col: 1, offset: 1784},
 			expr: &actionExpr{
-				pos: position{line: 68, col: 10, offset: 1796},
+				pos: position{line: 68, col: 10, offset: 1793},
 				run: (*parser).calloncase041,
 				expr: &seqExpr{
-					pos: position{line: 68, col: 10, offset: 1796},
+					pos: position{line: 68, col: 10, offset: 1793},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 68, col: 10, offset: 1796},
+							pos:        position{line: 68, col: 10, offset: 1793},
 							val:        "case04:",
 							ignoreCase: false,
 							want:       "\"case04:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 68, col: 20, offset: 1806},
+							pos:   position{line: 68, col: 20, offset: 1803},
 							label: "case04",
 							expr: &ruleRefExpr{
-								pos:  position{line: 68, col: 27, offset: 1813},
+								pos:  position{line: 68, col: 27, offset: 1810},
 								name: "OuterRecover04",
 							},
 						},
@@ -590,17 +590,17 @@ var g = &grammar{
 		},
 		{
 			name: "OuterRecover04",
-			pos:  position{line: 70, col: 1, offset: 1852},
+			pos:  position{line: 70, col: 1, offset: 1849},
 			expr: &recoveryExpr{
-				pos: position{line: 70, col: 18, offset: 1869},
+				pos: position{line: 70, col: 18, offset: 1866},
 				expr: &recoveryExpr{
-					pos: position{line: 70, col: 18, offset: 1869},
+					pos: position{line: 70, col: 18, offset: 1866},
 					expr: &ruleRefExpr{
-						pos:  position{line: 70, col: 18, offset: 1869},
+						pos:  position{line: 70, col: 18, offset: 1866},
 						name: "InnerRecover04",
 					},
 					recoverExpr: &ruleRefExpr{
-						pos:  position{line: 70, col: 66, offset: 1917},
+						pos:  position{line: 70, col: 66, offset: 1914},
 						name: "ErrAlphaOuter04",
 					},
 					failureLabel: []string{
@@ -609,7 +609,7 @@ var g = &grammar{
 					},
 				},
 				recoverExpr: &ruleRefExpr{
-					pos:  position{line: 70, col: 95, offset: 1946},
+					pos:  position{line: 70, col: 95, offset: 1943},
 					name: "ErrOtherOuter04",
 				},
 				failureLabel: []string{
@@ -619,15 +619,15 @@ var g = &grammar{
 		},
 		{
 			name: "InnerRecover04",
-			pos:  position{line: 72, col: 1, offset: 1963},
+			pos:  position{line: 72, col: 1, offset: 1960},
 			expr: &recoveryExpr{
-				pos: position{line: 72, col: 18, offset: 1980},
+				pos: position{line: 72, col: 18, offset: 1977},
 				expr: &ruleRefExpr{
-					pos:  position{line: 72, col: 18, offset: 1980},
+					pos:  position{line: 72, col: 18, offset: 1977},
 					name: "number04",
 				},
 				recoverExpr: &ruleRefExpr{
-					pos:  position{line: 72, col: 45, offset: 2007},
+					pos:  position{line: 72, col: 45, offset: 2004},
 					name: "ErrAlphaInner04",
 				},
 				failureLabel: []string{
@@ -637,35 +637,35 @@ var g = &grammar{
 		},
 		{
 			name: "number04",
-			pos:  position{line: 74, col: 1, offset: 2024},
+			pos:  position{line: 74, col: 1, offset: 2021},
 			expr: &choiceExpr{
-				pos: position{line: 74, col: 12, offset: 2035},
+				pos: position{line: 74, col: 12, offset: 2032},
 				alternatives: []any{
 					&notExpr{
-						pos: position{line: 74, col: 12, offset: 2035},
+						pos: position{line: 74, col: 12, offset: 2032},
 						expr: &anyMatcher{
-							line: 74, col: 13, offset: 2036,
+							line: 74, col: 13, offset: 2033,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 74, col: 17, offset: 2040},
+						pos: position{line: 74, col: 17, offset: 2037},
 						run: (*parser).callonnumber044,
 						expr: &seqExpr{
-							pos: position{line: 74, col: 17, offset: 2040},
+							pos: position{line: 74, col: 17, offset: 2037},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 74, col: 17, offset: 2040},
+									pos:   position{line: 74, col: 17, offset: 2037},
 									label: "d",
 									expr: &ruleRefExpr{
-										pos:  position{line: 74, col: 19, offset: 2042},
+										pos:  position{line: 74, col: 19, offset: 2039},
 										name: "digit04",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 74, col: 27, offset: 2050},
+									pos:   position{line: 74, col: 27, offset: 2047},
 									label: "n",
 									expr: &ruleRefExpr{
-										pos:  position{line: 74, col: 29, offset: 2052},
+										pos:  position{line: 74, col: 29, offset: 2049},
 										name: "number04",
 									},
 								},
@@ -677,15 +677,15 @@ var g = &grammar{
 		},
 		{
 			name: "digit04",
-			pos:  position{line: 81, col: 1, offset: 2161},
+			pos:  position{line: 81, col: 1, offset: 2158},
 			expr: &choiceExpr{
-				pos: position{line: 81, col: 11, offset: 2171},
+				pos: position{line: 81, col: 11, offset: 2168},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 81, col: 11, offset: 2171},
+						pos: position{line: 81, col: 11, offset: 2168},
 						run: (*parser).callondigit042,
 						expr: &charClassMatcher{
-							pos:        position{line: 81, col: 11, offset: 2171},
+							pos:        position{line: 81, col: 11, offset: 2168},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -693,18 +693,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 81, col: 50, offset: 2210},
+						pos: position{line: 81, col: 50, offset: 2207},
 						run: (*parser).callondigit044,
 						expr: &labeledExpr{
-							pos:   position{line: 81, col: 50, offset: 2210},
+							pos:   position{line: 81, col: 50, offset: 2207},
 							label: "x",
 							expr: &seqExpr{
-								pos: position{line: 81, col: 54, offset: 2214},
+								pos: position{line: 81, col: 54, offset: 2211},
 								exprs: []any{
 									&andExpr{
-										pos: position{line: 81, col: 54, offset: 2214},
+										pos: position{line: 81, col: 54, offset: 2211},
 										expr: &charClassMatcher{
-											pos:        position{line: 81, col: 55, offset: 2215},
+											pos:        position{line: 81, col: 55, offset: 2212},
 											val:        "[a-z]",
 											ranges:     []rune{'a', 'z'},
 											ignoreCase: false,
@@ -712,7 +712,7 @@ var g = &grammar{
 										},
 									},
 									&throwExpr{
-										pos:   position{line: 81, col: 61, offset: 2221},
+										pos:   position{line: 81, col: 61, offset: 2218},
 										label: "errAlphaLower",
 									},
 								},
@@ -720,18 +720,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 81, col: 111, offset: 2271},
+						pos: position{line: 81, col: 111, offset: 2268},
 						run: (*parser).callondigit0410,
 						expr: &labeledExpr{
-							pos:   position{line: 81, col: 111, offset: 2271},
+							pos:   position{line: 81, col: 111, offset: 2268},
 							label: "x",
 							expr: &seqExpr{
-								pos: position{line: 81, col: 115, offset: 2275},
+								pos: position{line: 81, col: 115, offset: 2272},
 								exprs: []any{
 									&andExpr{
-										pos: position{line: 81, col: 115, offset: 2275},
+										pos: position{line: 81, col: 115, offset: 2272},
 										expr: &charClassMatcher{
-											pos:        position{line: 81, col: 116, offset: 2276},
+											pos:        position{line: 81, col: 116, offset: 2273},
 											val:        "[A-Z]",
 											ranges:     []rune{'A', 'Z'},
 											ignoreCase: false,
@@ -739,7 +739,7 @@ var g = &grammar{
 										},
 									},
 									&throwExpr{
-										pos:   position{line: 81, col: 122, offset: 2282},
+										pos:   position{line: 81, col: 122, offset: 2279},
 										label: "errAlphaUpper",
 									},
 								},
@@ -747,7 +747,7 @@ var g = &grammar{
 						},
 					},
 					&throwExpr{
-						pos:   position{line: 81, col: 172, offset: 2332},
+						pos:   position{line: 81, col: 172, offset: 2329},
 						label: "errOther",
 					},
 				},
@@ -755,34 +755,34 @@ var g = &grammar{
 		},
 		{
 			name: "ErrAlphaInner04",
-			pos:  position{line: 83, col: 1, offset: 2345},
+			pos:  position{line: 83, col: 1, offset: 2342},
 			expr: &andCodeExpr{
-				pos: position{line: 83, col: 19, offset: 2363},
+				pos: position{line: 83, col: 19, offset: 2360},
 				run: (*parser).callonErrAlphaInner041,
 			},
 		},
 		{
 			name: "ErrAlphaOuter04",
-			pos:  position{line: 87, col: 1, offset: 2391},
+			pos:  position{line: 87, col: 1, offset: 2388},
 			expr: &actionExpr{
-				pos: position{line: 87, col: 19, offset: 2409},
+				pos: position{line: 87, col: 19, offset: 2406},
 				run: (*parser).callonErrAlphaOuter041,
 				expr: &seqExpr{
-					pos: position{line: 87, col: 19, offset: 2409},
+					pos: position{line: 87, col: 19, offset: 2406},
 					exprs: []any{
 						&andCodeExpr{
-							pos: position{line: 87, col: 19, offset: 2409},
+							pos: position{line: 87, col: 19, offset: 2406},
 							run: (*parser).callonErrAlphaOuter043,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 89, col: 3, offset: 2476},
+							pos: position{line: 89, col: 3, offset: 2473},
 							expr: &seqExpr{
-								pos: position{line: 89, col: 5, offset: 2478},
+								pos: position{line: 89, col: 5, offset: 2475},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 89, col: 5, offset: 2478},
+										pos: position{line: 89, col: 5, offset: 2475},
 										expr: &charClassMatcher{
-											pos:        position{line: 89, col: 6, offset: 2479},
+											pos:        position{line: 89, col: 6, offset: 2476},
 											val:        "[0-9]",
 											ranges:     []rune{'0', '9'},
 											ignoreCase: false,
@@ -790,7 +790,7 @@ var g = &grammar{
 										},
 									},
 									&anyMatcher{
-										line: 89, col: 12, offset: 2485,
+										line: 89, col: 12, offset: 2482,
 									},
 								},
 							},
@@ -801,26 +801,26 @@ var g = &grammar{
 		},
 		{
 			name: "ErrOtherOuter04",
-			pos:  position{line: 91, col: 1, offset: 2511},
+			pos:  position{line: 91, col: 1, offset: 2508},
 			expr: &actionExpr{
-				pos: position{line: 91, col: 19, offset: 2529},
+				pos: position{line: 91, col: 19, offset: 2526},
 				run: (*parser).callonErrOtherOuter041,
 				expr: &seqExpr{
-					pos: position{line: 91, col: 19, offset: 2529},
+					pos: position{line: 91, col: 19, offset: 2526},
 					exprs: []any{
 						&andCodeExpr{
-							pos: position{line: 91, col: 19, offset: 2529},
+							pos: position{line: 91, col: 19, offset: 2526},
 							run: (*parser).callonErrOtherOuter043,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 93, col: 3, offset: 2600},
+							pos: position{line: 93, col: 3, offset: 2597},
 							expr: &seqExpr{
-								pos: position{line: 93, col: 5, offset: 2602},
+								pos: position{line: 93, col: 5, offset: 2599},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 93, col: 5, offset: 2602},
+										pos: position{line: 93, col: 5, offset: 2599},
 										expr: &charClassMatcher{
-											pos:        position{line: 93, col: 6, offset: 2603},
+											pos:        position{line: 93, col: 6, offset: 2600},
 											val:        "[0-9]",
 											ranges:     []rune{'0', '9'},
 											ignoreCase: false,
@@ -828,7 +828,7 @@ var g = &grammar{
 										},
 									},
 									&anyMatcher{
-										line: 93, col: 12, offset: 2609,
+										line: 93, col: 12, offset: 2606,
 									},
 								},
 							},

--- a/test/thrownrecover/thrownrecover.go
+++ b/test/thrownrecover/thrownrecover.go
@@ -904,7 +904,7 @@ func (p *parser) callonErrNonNumber1() (any, error) {
 }
 
 func (c *current) oncase025() (bool, error) {
-	return false, errors.New("Throwed undefined label")
+	return false, errors.New("Threw undefined label")
 }
 
 func (p *parser) calloncase025() (bool, error) {
@@ -1143,7 +1143,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/test/thrownrecover/thrownrecover.peg
+++ b/test/thrownrecover/thrownrecover.peg
@@ -8,7 +8,7 @@ Start = case01 / case02 / case03 / case04
 
 // Case 01: Multiple Label Recover
 
-case01 = "case01:" case01:MultiLabelRecover { return case01, nil } 
+case01 = "case01:" case01:MultiLabelRecover { return case01, nil }
 
 MultiLabelRecover = number //{errAlpha, errOther} ErrNonNumber
 
@@ -28,7 +28,7 @@ ErrNonNumber = &{
 
 // Case 02: Throw Undefined Label
 
-case02 = "case02:" (ThrowUndefLabel / &{ return false, errors.New("Throwed undefined label") })
+case02 = "case02:" (ThrowUndefLabel / &{ return false, errors.New("Threw undefined label") })
 
 ThrowUndefLabel = %{undeflabel}
 

--- a/test/thrownrecover/thrownrecover_test.go
+++ b/test/thrownrecover/thrownrecover_test.go
@@ -36,7 +36,7 @@ func TestThrowAndRecover(t *testing.T) {
 			input:    "case02:",
 			captures: nil,
 			errors: []string{
-				"1:8 (7): rule case02: Throwed undefined label",
+				"1:8 (7): rule case02: Threw undefined label",
 			},
 		},
 


### PR DESCRIPTION
I stumbled upon the "expresssions" typo in the generated code of my language and then ran the spellchecker on Pigeon, finding a few other minor typos.