### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,42 +14,28 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO_VERSION: "stable"
-      GOLANGCI_LINT_VERSION: v1.61.0
+      GOLANGCI_LINT_VERSION: v1.62.0
       CGO_ENABLED: 0
 
     steps:
 
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Check and get dependencies
-        run: |
-          go mod tidy
-          git diff --exit-code go.mod
-          git diff --exit-code go.sum
+        run: go mod tidy -diff
 
-      - name: Install golangci-lint ${{ env.GOLANGCI_LINT_VERSION }}
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
-          golangci-lint --version
-
-      - name: Lint
-        run: golangci-lint run
+      - name: golangci-lint action ${{ env.GOLANGCI_LINT_VERSION }}
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
 
       - name: Test
         run: go test -v -cover ./...

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -12,10 +12,10 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "stable"
-      - uses: actions/go-dependency-submission@v1
+      - uses: actions/go-dependency-submission@v2
         with:
           go-mod-path: go.mod

--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Go modules
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       -
         name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "stable"
 


### PR DESCRIPTION
* actions/checkout v4 is available
* actions/setup-go v5 is availabe, v4+ has an integrated cache
  * Caching in ci.yml was removed
  * Caching in go-cross.yml was not touched because more stuff is cached
* actions/cache v4 is available
* golangci/golangci-lint-action is available and has CI optimized caching integrated
* Go 1.23 (current stable) can check clean dependencies with `go mod tidy -diff`
* actions/go-dependency-submission v2 is available