### PR TITLE
Update actions/cache to v4

### DIFF
--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache Go modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # In order:
           # * Module download cache


### PR DESCRIPTION
* This was missed at https://github.com/mna/pigeon/pull/162
* This change should provoke less warnings in GitHub actions