### PR TITLE
builder: pick a stable leader for left recursion

### DIFF
--- a/builder/left_recursion.go
+++ b/builder/left_recursion.go
@@ -65,11 +65,12 @@ func findLeader(
 			}
 		}
 	}
-	// Pick an arbitrary leader from the candidates.
+	// Pick an arbitrary but stable leader from the candidates.
 	var leader string
 	for k := range leaders {
-		leader = k // The only element.
-		break
+		if leader == "" || k < leader {
+			leader = k
+		}
 	}
 	return leader, nil
 }

--- a/builder/left_recursion_test.go
+++ b/builder/left_recursion_test.go
@@ -159,6 +159,12 @@ func TestMutuallyLeftRecursive(t *testing.T) {
 	if !mapRules["bar"].LeftRecursive {
 		t.Error("Rule 'bar' contains left recursion")
 	}
+	if mapRules["foo"].Leader {
+		t.Error("Rule 'foo' should not be the stable left-recursion leader")
+	}
+	if !mapRules["bar"].Leader {
+		t.Error("Rule 'bar' should be the stable left-recursion leader")
+	}
 }
 
 func TestNastyMutuallyLeftRecursive(t *testing.T) {


### PR DESCRIPTION
Previously this just picked an arbitrary leader based on map iteration order, so you'd get `leader: true` and `leader: false` swapping between rules randomly on every re-generation.